### PR TITLE
Refactor repositories to provider architecture

### DIFF
--- a/lib/core/utils/banner_manager.dart
+++ b/lib/core/utils/banner_manager.dart
@@ -1,19 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
 import '../../models/banner_config.dart';
-import '../../repository/lembaga_repository.dart';
+import '../../providers/lembaga_provider.dart';
 
 class BannerManager {
   static final BannerManager _instance = BannerManager._internal();
   factory BannerManager() => _instance;
   BannerManager._internal();
 
-  final LembagaRepository _repository = LembagaRepository();
-
   // Cache untuk menyimpan banner configs per lembaga
   final Map<String, BannerConfig> _bannerCache = {};
 
   /// Get banner config untuk menu tertentu
-  Future<BannerConfig> getBannerConfig(String menuKey,
-      {String? lembagaSlug}) async {
+  Future<BannerConfig> getBannerConfig(
+    BuildContext context,
+    String menuKey, {
+    String? lembagaSlug,
+  }) async {
     // Untuk banner yang sama di semua menu lembaga, kita cuma perlu lembagaSlug
     final cacheKey = lembagaSlug ?? 'default';
 
@@ -25,7 +29,8 @@ class BannerManager {
     try {
       // Jika ada lembagaSlug, ambil banner dari API
       if (lembagaSlug != null) {
-        final lembaga = await _repository.fetchBySlug(lembagaSlug);
+        final provider = Provider.of<LembagaProvider>(context, listen: false);
+        final lembaga = await provider.fetchBySlug(lembagaSlug);
         if (lembaga != null) {
           // Buat banner config dari topBanner dan botBanner lembaga
           final bannerConfig = BannerConfig.fromLembaga(
@@ -60,9 +65,11 @@ class BannerManager {
   }
 
   /// Pre-load banner config dari lembaga (topBanner & botBanner)
-  Future<void> preloadBannerConfigs(String lembagaSlug) async {
+  Future<void> preloadBannerConfigs(
+      BuildContext context, String lembagaSlug) async {
     try {
-      final lembaga = await _repository.fetchBySlug(lembagaSlug);
+      final provider = Provider.of<LembagaProvider>(context, listen: false);
+      final lembaga = await provider.fetchBySlug(lembagaSlug);
       if (lembaga != null) {
         // Buat banner config dari topBanner dan botBanner lembaga
         final bannerConfig = BannerConfig.fromLembaga(

--- a/lib/core/utils/menu_navigation_helper.dart
+++ b/lib/core/utils/menu_navigation_helper.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../screens/galeri_screen.dart';
 import '../../screens/contact_screen.dart';
 import '../../screens/bannered_detail_screen.dart';
@@ -9,12 +10,11 @@ import '../../screens/alumni_screen.dart';
 import '../../screens/prestasi_santri_screen.dart';
 import '../../models/profile_section.dart';
 import '../../models/lembaga_model.dart';
-import '../../repository/lembaga_repository.dart';
+import '../../providers/lembaga_provider.dart';
 import 'banner_manager.dart';
 import '../constants/profil.dart';
 
 class MenuNavigationHelper {
-  static final LembagaRepository _lembagaRepository = LembagaRepository();
   static final BannerManager _bannerManager = BannerManager();
 
   /// Navigate to appropriate screen based on menu item and lembaga slug
@@ -48,7 +48,9 @@ class MenuNavigationHelper {
     );
 
     try {
-      final lembaga = await _lembagaRepository.fetchBySlug(slug);
+      final provider = Provider.of<LembagaProvider>(context, listen: false);
+      final lembaga = await provider.fetchBySlug(slug);
+      final errorMessage = provider.lembagaState(slug).errorMessage;
 
       // Dismiss loading
       if (context.mounted) {
@@ -58,8 +60,9 @@ class MenuNavigationHelper {
       if (lembaga == null) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Data lembaga tidak ditemukan'),
+            SnackBar(
+              content: Text(
+                  errorMessage ?? 'Data lembaga tidak ditemukan'),
               backgroundColor: Colors.red,
             ),
           );
@@ -244,8 +247,11 @@ class MenuNavigationHelper {
   static void _navigateWithBanner(BuildContext context, String menuItem,
       String categoryTitle, String? lembagaSlug) async {
     // Get banner config
-    final bannerConfig = await _bannerManager.getBannerConfig(menuItem,
-        lembagaSlug: lembagaSlug);
+    final bannerConfig = await _bannerManager.getBannerConfig(
+      context,
+      menuItem,
+      lembagaSlug: lembagaSlug,
+    );
 
     if (!context.mounted) return;
 
@@ -436,8 +442,11 @@ class MenuNavigationHelper {
         '🎯 [CONTENT_BANNER] Menu: $menuItem, hasContent: ${markdownContent != null}');
 
     // Get banner config from lembaga
-    final bannerConfig = await _bannerManager.getBannerConfig(menuItem,
-        lembagaSlug: lembaga.slug);
+    final bannerConfig = await _bannerManager.getBannerConfig(
+      context,
+      menuItem,
+      lembagaSlug: lembaga.slug,
+    );
 
     print(
         '🎯 [CONTENT_BANNER] Banner config loaded - hasTopBanner: ${bannerConfig.hasTopBanner}, hasBottomBanner: ${bannerConfig.hasBottomBanner}');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,19 @@ import 'package:provider/provider.dart';
 import 'core/utils/auth_utils.dart';
 import 'core/theme/app_colors.dart';
 import 'core/router/app_router.dart';
+import 'providers/achievement_provider.dart';
+import 'providers/auth_provider.dart';
+import 'providers/banner_menu_utama_provider.dart';
 import 'providers/donasi_provider.dart';
+import 'providers/informasi_al_ittifaqiah_provider.dart';
+import 'providers/kehadiran_provider.dart';
+import 'providers/kelas_provider.dart';
+import 'providers/lembaga_provider.dart';
+import 'providers/prestasi_provider.dart';
+import 'providers/santri_provider.dart';
+import 'providers/slider_provider.dart';
+import 'providers/staff_provider.dart';
+import 'providers/tahun_ajaran_provider.dart';
 
 /// Entry point of the Pesantren application.
 ///
@@ -34,9 +46,20 @@ class PesantrenApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (_) => DonasiProvider()),
+        ChangeNotifierProvider(create: (_) => SliderProvider()),
+        ChangeNotifierProvider(create: (_) => AchievementProvider()),
+        ChangeNotifierProvider(create: (_) => LembagaProvider()),
+        ChangeNotifierProvider(create: (_) => BannerMenuUtamaProvider()),
+        ChangeNotifierProvider(create: (_) => SantriProvider()),
+        ChangeNotifierProvider(create: (_) => KelasProvider()),
+        ChangeNotifierProvider(create: (_) => StaffProvider()),
+        ChangeNotifierProvider(create: (_) => KehadiranProvider()),
+        ChangeNotifierProvider(create: (_) => PrestasiProvider()),
         ChangeNotifierProvider(
-          create: (_) => DonasiProvider(),
-        ),
+            create: (_) => InformasiAlIttifaqiahProvider()),
+        ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => TahunAjaranProvider()),
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,

--- a/lib/providers/achievement_provider.dart
+++ b/lib/providers/achievement_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/achievement_model.dart';
+import '../repository/achievement_repository.dart';
+import 'async_value.dart';
+
+class AchievementProvider extends ChangeNotifier {
+  AchievementProvider({AchievementRepository? repository})
+      : _repository = repository ?? AchievementRepository();
+
+  final AchievementRepository _repository;
+  final AsyncValue<List<AchievementModel>> _achievementsState =
+      AsyncValue<List<AchievementModel>>(data: const []);
+
+  AsyncValue<List<AchievementModel>> get achievementsState =>
+      _achievementsState;
+
+  List<AchievementModel> get achievements =>
+      List.unmodifiable(_achievementsState.data ?? const []);
+
+  Future<void> fetchAchievements({bool forceRefresh = false}) async {
+    if (_achievementsState.isLoading) return;
+    if (_achievementsState.hasLoaded && !forceRefresh) return;
+
+    _achievementsState.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.fetchAchievements();
+      _achievementsState.setData(List.unmodifiable(result));
+    } catch (error) {
+      _achievementsState.setError(error);
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  void clear() {
+    _achievementsState.reset();
+    notifyListeners();
+  }
+}

--- a/lib/providers/async_value.dart
+++ b/lib/providers/async_value.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+
+/// Represents the loading state of an asynchronous resource.
+class AsyncValue<T> {
+  AsyncValue({
+    this.data,
+    this.isLoading = false,
+    this.errorMessage,
+    this.hasLoaded = false,
+  });
+
+  T? data;
+  bool isLoading;
+  String? errorMessage;
+  bool hasLoaded;
+
+  bool get hasError => errorMessage != null;
+
+  void startLoading() {
+    isLoading = true;
+    errorMessage = null;
+  }
+
+  void setData(T value) {
+    data = value;
+    isLoading = false;
+    hasLoaded = true;
+    errorMessage = null;
+  }
+
+  void setNullableData(T? value) {
+    data = value;
+    isLoading = false;
+    hasLoaded = true;
+    errorMessage = null;
+  }
+
+  void setError(Object error) {
+    errorMessage = error.toString();
+    isLoading = false;
+    hasLoaded = true;
+  }
+
+  void reset() {
+    data = null;
+    isLoading = false;
+    errorMessage = null;
+    hasLoaded = false;
+  }
+
+  @override
+  String toString() {
+    return 'AsyncValue(isLoading: ' +
+        isLoading.toString() +
+        ', hasLoaded: ' +
+        hasLoaded.toString() +
+        ', error: ' +
+        errorMessage.toString() +
+        ', data: ' +
+        (kDebugMode ? data.toString() : '<omitted>') +
+        ')';
+  }
+}

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+
+import '../repository/auth_repository.dart';
+
+class AuthProvider extends ChangeNotifier {
+  AuthProvider({AuthRepository? repository})
+      : _repository = repository ?? AuthRepository();
+
+  final AuthRepository _repository;
+
+  bool _isAuthenticating = false;
+  String? _authError;
+
+  bool get isAuthenticating => _isAuthenticating;
+  String? get authError => _authError;
+
+  Future<bool> login({
+    required String identifier,
+    required String password,
+  }) async {
+    if (_isAuthenticating) return false;
+
+    _isAuthenticating = true;
+    _authError = null;
+    notifyListeners();
+
+    try {
+      final message = await _repository.login(
+        identifier: identifier,
+        password: password,
+      );
+
+      if (message == null) {
+        return true;
+      }
+
+      _authError = message;
+      return false;
+    } catch (error) {
+      _authError = error.toString();
+      return false;
+    } finally {
+      _isAuthenticating = false;
+      notifyListeners();
+    }
+  }
+
+  void clearError() {
+    _authError = null;
+    notifyListeners();
+  }
+}

--- a/lib/providers/banner_menu_utama_provider.dart
+++ b/lib/providers/banner_menu_utama_provider.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/banner_menu_utama_model.dart';
+import '../repository/banner_menu_utama_repository.dart';
+import 'async_value.dart';
+
+class BannerMenuUtamaProvider extends ChangeNotifier {
+  BannerMenuUtamaProvider({BannerMenuUtamaRepository? repository})
+      : _repository = repository ?? BannerMenuUtamaRepository();
+
+  final BannerMenuUtamaRepository _repository;
+  final Map<String, AsyncValue<BannerMenuUtama?>> _bannerStates = {};
+
+  AsyncValue<BannerMenuUtama?> bannerState(String title) {
+    return _bannerStates.putIfAbsent(
+      title,
+      () => AsyncValue<BannerMenuUtama?>(),
+    );
+  }
+
+  Future<BannerMenuUtama?> fetchBanner(String title,
+      {bool forceRefresh = false}) async {
+    final state = bannerState(title);
+
+    if (state.isLoading) return state.data;
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data;
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final banner = await _repository.getBannerByTitle(title);
+      state.setNullableData(banner);
+      return banner;
+    } catch (error) {
+      state.setError(error);
+      return null;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  void clearBanner(String title) {
+    _bannerStates.remove(title);
+    notifyListeners();
+  }
+}

--- a/lib/providers/informasi_al_ittifaqiah_provider.dart
+++ b/lib/providers/informasi_al_ittifaqiah_provider.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/informasi_al_ittifaqiah_model.dart';
+import '../repository/informasi_al_ittifaqiah_repository.dart';
+import 'async_value.dart';
+
+class InformasiAlIttifaqiahProvider extends ChangeNotifier {
+  InformasiAlIttifaqiahProvider({InformasiAlIttifaqiahRepository? repository})
+      : _repository = repository ?? InformasiAlIttifaqiahRepository();
+
+  final InformasiAlIttifaqiahRepository _repository;
+  final AsyncValue<InformasiAlIttifaqiah?> _informasiState =
+      AsyncValue<InformasiAlIttifaqiah?>();
+
+  AsyncValue<InformasiAlIttifaqiah?> get informasiState => _informasiState;
+
+  InformasiAlIttifaqiah? get informasi => _informasiState.data;
+
+  Future<InformasiAlIttifaqiah?> fetchInformasi({
+    bool forceRefresh = false,
+  }) async {
+    if (_informasiState.isLoading) return _informasiState.data;
+    if (_informasiState.hasLoaded && !forceRefresh) {
+      return _informasiState.data;
+    }
+
+    _informasiState.startLoading();
+    notifyListeners();
+
+    try {
+      final data = await _repository.fetchInformasiAlIttifaqiah();
+      _informasiState.setNullableData(data);
+      return data;
+    } catch (error) {
+      _informasiState.setError(error);
+      return null;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<List<NewsItem>> fetchNews({bool forceRefresh = false}) async {
+    final data = await fetchInformasi(forceRefresh: forceRefresh);
+    return data?.news ?? const [];
+  }
+
+  Future<Map<String, List<GaleriItem>>> fetchGaleri({
+    bool forceRefresh = false,
+  }) async {
+    final data = await fetchInformasi(forceRefresh: forceRefresh);
+    return {
+      'galeriTamu': data?.galeriTamu ?? const [],
+      'galeriLuarNegeri': data?.galeriLuarNegeri ?? const [],
+      'bluePrintISCI': data?.bluePrintISCI ?? const [],
+    };
+  }
+
+  Future<Map<String, List<StatistikItem>>> fetchStatistik({
+    bool forceRefresh = false,
+  }) async {
+    final data = await fetchInformasi(forceRefresh: forceRefresh);
+    return {
+      'santri': data?.santri ?? const [],
+      'sdm': data?.sdm ?? const [],
+      'alumni': data?.alumni ?? const [],
+    };
+  }
+
+  void clear() {
+    _informasiState.reset();
+    notifyListeners();
+  }
+}

--- a/lib/providers/kehadiran_provider.dart
+++ b/lib/providers/kehadiran_provider.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/kehadiran_guru.dart';
+import '../models/kehadiran_santri.dart';
+import '../repository/kehadiran_repository.dart';
+import 'async_value.dart';
+
+class KehadiranProvider extends ChangeNotifier {
+  KehadiranProvider({KehadiranRepository? repository})
+      : _repository = repository ?? KehadiranRepository();
+
+  final KehadiranRepository _repository;
+
+  final Map<String, AsyncValue<List<KehadiranSantri>>> _santriStates = {};
+  final Map<String, AsyncValue<List<KehadiranGuru>>> _guruStates = {};
+
+  AsyncValue<List<KehadiranSantri>> santriState(
+    String lembagaSlug, {
+    DateTime? startDate,
+    DateTime? endDate,
+  }) {
+    final key = _santriKey(lembagaSlug, startDate, endDate);
+    return _santriStates.putIfAbsent(
+      key,
+      () => AsyncValue<List<KehadiranSantri>>(data: const []),
+    );
+  }
+
+  AsyncValue<List<KehadiranGuru>> guruState(
+    String lembagaSlug, {
+    DateTime? startDate,
+    DateTime? endDate,
+  }) {
+    final key = _guruKey(lembagaSlug, startDate, endDate);
+    return _guruStates.putIfAbsent(
+      key,
+      () => AsyncValue<List<KehadiranGuru>>(data: const []),
+    );
+  }
+
+  Future<List<KehadiranSantri>> fetchSantriByLembaga(
+    String lembagaSlug, {
+    bool forceRefresh = false,
+  }) async {
+    return _loadSantri(
+      lembagaSlug,
+      null,
+      null,
+      () => _repository.getKehadiranSantriByLembaga(lembagaSlug),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<List<KehadiranSantri>> fetchSantriByDateRange(
+    String lembagaSlug,
+    DateTime startDate,
+    DateTime endDate, {
+    bool forceRefresh = false,
+  }) async {
+    return _loadSantri(
+      lembagaSlug,
+      startDate,
+      endDate,
+      () => _repository.getKehadiranSantriByDateRange(
+        lembagaSlug,
+        startDate,
+        endDate,
+      ),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<List<KehadiranGuru>> fetchGuruByLembaga(
+    String lembagaSlug, {
+    bool forceRefresh = false,
+  }) async {
+    return _loadGuru(
+      lembagaSlug,
+      null,
+      null,
+      () => _repository.getKehadiranGuruByLembaga(lembagaSlug),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<List<KehadiranGuru>> fetchGuruByDateRange(
+    String lembagaSlug,
+    DateTime startDate,
+    DateTime endDate, {
+    bool forceRefresh = false,
+  }) async {
+    return _loadGuru(
+      lembagaSlug,
+      startDate,
+      endDate,
+      () => _repository.getKehadiranGuruByDateRange(
+        lembagaSlug,
+        startDate,
+        endDate,
+      ),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<List<KehadiranSantri>> _loadSantri(
+    String slug,
+    DateTime? start,
+    DateTime? end,
+    Future<List<KehadiranSantri>> Function() loader, {
+    bool forceRefresh = false,
+  }) async {
+    final state = santriState(slug, startDate: start, endDate: end);
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await loader();
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<List<KehadiranGuru>> _loadGuru(
+    String slug,
+    DateTime? start,
+    DateTime? end,
+    Future<List<KehadiranGuru>> Function() loader, {
+    bool forceRefresh = false,
+  }) async {
+    final state = guruState(slug, startDate: start, endDate: end);
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await loader();
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  String _santriKey(String slug, DateTime? start, DateTime? end) {
+    final startKey = start?.toIso8601String() ?? '';
+    final endKey = end?.toIso8601String() ?? '';
+    return 'santri|$slug|$startKey|$endKey';
+  }
+
+  String _guruKey(String slug, DateTime? start, DateTime? end) {
+    final startKey = start?.toIso8601String() ?? '';
+    final endKey = end?.toIso8601String() ?? '';
+    return 'guru|$slug|$startKey|$endKey';
+  }
+}

--- a/lib/providers/kelas_provider.dart
+++ b/lib/providers/kelas_provider.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+
+import '../repository/kelas_repository.dart';
+import 'async_value.dart';
+
+class KelasProvider extends ChangeNotifier {
+  KelasProvider({KelasRepository? repository})
+      : _repository = repository ?? KelasRepository();
+
+  final KelasRepository _repository;
+  final Map<String, AsyncValue<List<String>>> _kelasBySlug = {};
+
+  AsyncValue<List<String>> kelasState(String slug) {
+    return _kelasBySlug.putIfAbsent(
+      slug,
+      () => AsyncValue<List<String>>(data: const []),
+    );
+  }
+
+  List<String> kelasList(String slug) {
+    final state = kelasState(slug);
+    return List.unmodifiable(state.data ?? const []);
+  }
+
+  Future<List<String>> fetchKelas(
+    String slug, {
+    int pageSize = 100,
+    bool forceRefresh = false,
+  }) async {
+    final state = kelasState(slug);
+
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getKelasByLembaga(
+        slug,
+        pageSize: pageSize,
+      );
+      final kelasNames = result
+          .map((kelas) => kelas.namaKelas)
+          .where((name) => name.isNotEmpty)
+          .toList();
+      state.setData(List.unmodifiable(kelasNames));
+      return kelasNames;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  void clearForSlug(String slug) {
+    _kelasBySlug.remove(slug);
+    notifyListeners();
+  }
+}

--- a/lib/providers/lembaga_provider.dart
+++ b/lib/providers/lembaga_provider.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/lembaga_model.dart';
+import '../repository/lembaga_repository.dart';
+import 'async_value.dart';
+
+class LembagaProvider extends ChangeNotifier {
+  LembagaProvider({LembagaRepository? repository})
+      : _repository = repository ?? LembagaRepository();
+
+  final LembagaRepository _repository;
+
+  final AsyncValue<List<Lembaga>> _lembagaListState =
+      AsyncValue<List<Lembaga>>(data: const []);
+  final Map<String, AsyncValue<Lembaga?>> _lembagaBySlug = {};
+
+  AsyncValue<List<Lembaga>> get lembagaListState => _lembagaListState;
+
+  List<Lembaga> get lembagaList =>
+      List.unmodifiable(_lembagaListState.data ?? const []);
+
+  AsyncValue<Lembaga?> lembagaState(String slug) {
+    return _lembagaBySlug.putIfAbsent(
+      slug,
+      () => AsyncValue<Lembaga?>(),
+    );
+  }
+
+  Lembaga? getCachedLembaga(String slug) => lembagaState(slug).data;
+
+  String? errorForSlug(String slug) => lembagaState(slug).errorMessage;
+
+  bool isLoadingSlug(String slug) => lembagaState(slug).isLoading;
+
+  Future<List<Lembaga>> fetchAll({bool forceRefresh = false}) async {
+    if (_lembagaListState.isLoading) return _lembagaListState.data ?? const [];
+    if (_lembagaListState.hasLoaded && !forceRefresh) {
+      return _lembagaListState.data ?? const [];
+    }
+
+    _lembagaListState.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.fetchAll();
+      _lembagaListState.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      _lembagaListState.setError(error);
+      return _lembagaListState.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<Lembaga?> fetchBySlug(String slug, {bool forceRefresh = false}) async {
+    final state = lembagaState(slug);
+    if (state.isLoading) return state.data;
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data;
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.fetchBySlug(slug);
+      state.setNullableData(result);
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  void clear() {
+    _lembagaListState.reset();
+    _lembagaBySlug.clear();
+    notifyListeners();
+  }
+}

--- a/lib/providers/prestasi_provider.dart
+++ b/lib/providers/prestasi_provider.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/prestasi.dart';
+import '../repository/prestasi_repository.dart';
+import 'async_value.dart';
+
+class PrestasiProvider extends ChangeNotifier {
+  PrestasiProvider({PrestasiRepository? repository})
+      : _repository = repository ?? PrestasiRepository();
+
+  final PrestasiRepository _repository;
+  final Map<String, AsyncValue<List<Prestasi>>> _prestasiStates = {};
+
+  AsyncValue<List<Prestasi>> prestasiState(
+    String lembagaSlug, {
+    String? tahun,
+    String? tingkat,
+  }) {
+    final key = _buildKey(lembagaSlug, tahun, tingkat);
+    return _prestasiStates.putIfAbsent(
+      key,
+      () => AsyncValue<List<Prestasi>>(data: const []),
+    );
+  }
+
+  Future<List<Prestasi>> fetchPrestasiByLembaga(
+    String lembagaSlug, {
+    String? tahun,
+    String? tingkat,
+    bool forceRefresh = false,
+  }) async {
+    final state = prestasiState(
+      lembagaSlug,
+      tahun: tahun,
+      tingkat: tingkat,
+    );
+
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getPrestasiByLembaga(
+        lembagaSlug,
+        tahun: tahun,
+        tingkat: tingkat,
+      );
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  String _buildKey(String slug, String? tahun, String? tingkat) {
+    final tahunKey = tahun ?? 'all';
+    final tingkatKey = tingkat ?? 'all';
+    return '$slug|$tahunKey|$tingkatKey';
+  }
+}

--- a/lib/providers/santri_provider.dart
+++ b/lib/providers/santri_provider.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/santri.dart';
+import '../repository/santri_repository.dart';
+import 'async_value.dart';
+
+class SantriProvider extends ChangeNotifier {
+  SantriProvider({SantriRepository? repository})
+      : _repository = repository ?? SantriRepository();
+
+  final SantriRepository _repository;
+  final Map<String, AsyncValue<List<Santri>>> _santriStates = {};
+  final Map<String, AsyncValue<List<Santri>>> _alumniStates = {};
+
+  AsyncValue<List<Santri>> santriState(String slug) {
+    return _santriStates.putIfAbsent(
+      slug,
+      () => AsyncValue<List<Santri>>(data: const []),
+    );
+  }
+
+  AsyncValue<List<Santri>> alumniState(String slug, {String? tahunMasuk}) {
+    final key = _alumniKey(slug, tahunMasuk);
+    return _alumniStates.putIfAbsent(
+      key,
+      () => AsyncValue<List<Santri>>(data: const []),
+    );
+  }
+
+  Future<List<Santri>> fetchSantriByLembaga(
+    String slug, {
+    bool forceRefresh = false,
+  }) async {
+    final state = santriState(slug);
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getSantriByLembaga(slug);
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<List<Santri>> fetchAlumniByLembaga(
+    String slug, {
+    String? tahunMasuk,
+    bool forceRefresh = false,
+  }) async {
+    final state = alumniState(slug, tahunMasuk: tahunMasuk);
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getAlumniByLembaga(
+        slug,
+        tahunMasuk: tahunMasuk,
+      );
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  String _alumniKey(String slug, String? tahunMasuk) {
+    final tahunKey = tahunMasuk ?? 'all';
+    return '$slug|$tahunKey';
+  }
+}

--- a/lib/providers/slider_provider.dart
+++ b/lib/providers/slider_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart';
+
+import '../repository/slider_repository.dart';
+import 'async_value.dart';
+
+class SliderProvider extends ChangeNotifier {
+  SliderProvider({SliderRepository? repository})
+      : _repository = repository ?? SliderRepository();
+
+  final SliderRepository _repository;
+  final AsyncValue<List<String>> _sliderState =
+      AsyncValue<List<String>>(data: const []);
+
+  AsyncValue<List<String>> get sliderState => _sliderState;
+  List<String> get imageUrls => List.unmodifiable(_sliderState.data ?? const []);
+
+  Future<List<String>> fetchSliderImages({bool forceRefresh = false}) async {
+    if (_sliderState.isLoading) return _sliderState.data ?? const [];
+    if (_sliderState.hasLoaded && !forceRefresh) {
+      return _sliderState.data ?? const [];
+    }
+
+    _sliderState.startLoading();
+    notifyListeners();
+
+    try {
+      final images = await _repository.fetchSliderImageUrls();
+      _sliderState.setData(List.unmodifiable(images));
+      return images;
+    } catch (error) {
+      _sliderState.setError(error);
+      return _sliderState.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  void clear() {
+    _sliderState.reset();
+    notifyListeners();
+  }
+}

--- a/lib/providers/staff_provider.dart
+++ b/lib/providers/staff_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/staff.dart';
+import '../repository/staff_repository.dart';
+import 'async_value.dart';
+
+class StaffProvider extends ChangeNotifier {
+  StaffProvider({StaffRepository? repository})
+      : _repository = repository ?? StaffRepository();
+
+  final StaffRepository _repository;
+  final Map<String, AsyncValue<List<Staff>>> _staffStates = {};
+
+  AsyncValue<List<Staff>> staffState(String slug) {
+    return _staffStates.putIfAbsent(
+      slug,
+      () => AsyncValue<List<Staff>>(data: const []),
+    );
+  }
+
+  Future<List<Staff>> fetchStaffByLembaga(
+    String slug, {
+    bool forceRefresh = false,
+  }) async {
+    final state = staffState(slug);
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getStaffByLembaga(slug);
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+}

--- a/lib/providers/tahun_ajaran_provider.dart
+++ b/lib/providers/tahun_ajaran_provider.dart
@@ -1,0 +1,287 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/tahun_ajaran.dart';
+import '../repository/tahun_ajaran_repository.dart';
+import 'async_value.dart';
+
+class TahunAjaranProvider extends ChangeNotifier {
+  TahunAjaranProvider({TahunAjaranRepository? repository})
+      : _repository = repository ?? TahunAjaranRepository();
+
+  final TahunAjaranRepository _repository;
+
+  final Map<String, AsyncValue<List<TahunAjaran>>> _listByLembaga = {};
+  final Map<String, AsyncValue<TahunAjaran?>> _activeByLembaga = {};
+  final Map<String, AsyncValue<TahunAjaran?>> _byNama = {};
+  final Map<String, AsyncValue<List<TahunAjaran>>> _byRange = {};
+  final Map<int, AsyncValue<TahunAjaran?>> _byId = {};
+
+  AsyncValue<List<TahunAjaran>> listState(
+    String lembagaSlug, {
+    int? page,
+    int? pageSize,
+  }) {
+    final key = _listKey(lembagaSlug, page: page, pageSize: pageSize);
+    return _listByLembaga.putIfAbsent(
+      key,
+      () => AsyncValue<List<TahunAjaran>>(data: const []),
+    );
+  }
+
+  AsyncValue<TahunAjaran?> activeState(String lembagaSlug) {
+    return _activeByLembaga.putIfAbsent(
+      lembagaSlug,
+      () => AsyncValue<TahunAjaran?>(),
+    );
+  }
+
+  AsyncValue<TahunAjaran?> namaState(String lembagaSlug, String nama) {
+    final key = _namaKey(lembagaSlug, nama);
+    return _byNama.putIfAbsent(
+      key,
+      () => AsyncValue<TahunAjaran?>(),
+    );
+  }
+
+  AsyncValue<List<TahunAjaran>> rangeState(
+    String lembagaSlug,
+    int startYear,
+    int endYear, {
+    int? page,
+    int? pageSize,
+  }) {
+    final key = _rangeKey(
+      lembagaSlug,
+      startYear,
+      endYear,
+      page: page,
+      pageSize: pageSize,
+    );
+    return _byRange.putIfAbsent(
+      key,
+      () => AsyncValue<List<TahunAjaran>>(data: const []),
+    );
+  }
+
+  AsyncValue<TahunAjaran?> idState(int id) {
+    return _byId.putIfAbsent(
+      id,
+      () => AsyncValue<TahunAjaran?>(),
+    );
+  }
+
+  List<TahunAjaran> cachedList(
+    String lembagaSlug, {
+    int? page,
+    int? pageSize,
+  }) {
+    return List.unmodifiable(
+      listState(lembagaSlug, page: page, pageSize: pageSize).data ?? const [],
+    );
+  }
+
+  TahunAjaran? cachedActive(String lembagaSlug) {
+    return activeState(lembagaSlug).data;
+  }
+
+  TahunAjaran? cachedByNama(String lembagaSlug, String nama) {
+    return namaState(lembagaSlug, nama).data;
+  }
+
+  TahunAjaran? cachedById(int id) {
+    return idState(id).data;
+  }
+
+  Future<List<TahunAjaran>> fetchByLembaga(
+    String lembagaSlug, {
+    int? page,
+    int? pageSize,
+    bool forceRefresh = false,
+  }) async {
+    final state = listState(lembagaSlug, page: page, pageSize: pageSize);
+
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getTahunAjaranByLembaga(
+        lembagaSlug,
+        page: page,
+        pageSize: pageSize,
+      );
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<TahunAjaran?> fetchActiveTahunAjaran(
+    String lembagaSlug, {
+    bool forceRefresh = false,
+  }) async {
+    final state = activeState(lembagaSlug);
+
+    if (state.isLoading) return state.data;
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data;
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result =
+          await _repository.getActiveTahunAjaranByLembaga(lembagaSlug);
+      state.setNullableData(result);
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<TahunAjaran?> fetchByNama(
+    String lembagaSlug,
+    String nama, {
+    bool forceRefresh = false,
+  }) async {
+    final state = namaState(lembagaSlug, nama);
+
+    if (state.isLoading) return state.data;
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data;
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getTahunAjaranByNama(
+        lembagaSlug,
+        nama,
+      );
+      state.setNullableData(result);
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<List<TahunAjaran>> fetchByYearRange(
+    String lembagaSlug,
+    int startYear,
+    int endYear, {
+    int? page,
+    int? pageSize,
+    bool forceRefresh = false,
+  }) async {
+    final state = rangeState(
+      lembagaSlug,
+      startYear,
+      endYear,
+      page: page,
+      pageSize: pageSize,
+    );
+
+    if (state.isLoading) return state.data ?? const [];
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data ?? const [];
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getTahunAjaranByYearRange(
+        lembagaSlug,
+        startYear,
+        endYear,
+        page: page,
+        pageSize: pageSize,
+      );
+      state.setData(List.unmodifiable(result));
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data ?? const [];
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<TahunAjaran?> fetchById(
+    int id, {
+    bool forceRefresh = false,
+  }) async {
+    final state = idState(id);
+
+    if (state.isLoading) return state.data;
+    if (state.hasLoaded && !forceRefresh) {
+      return state.data;
+    }
+
+    state.startLoading();
+    notifyListeners();
+
+    try {
+      final result = await _repository.getTahunAjaranById(id);
+      state.setNullableData(result);
+      return result;
+    } catch (error) {
+      state.setError(error);
+      return state.data;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  void clearCache() {
+    _listByLembaga.clear();
+    _activeByLembaga.clear();
+    _byNama.clear();
+    _byRange.clear();
+    _byId.clear();
+    notifyListeners();
+  }
+
+  String _listKey(
+    String lembagaSlug, {
+    int? page,
+    int? pageSize,
+  }) {
+    final normalizedSlug = lembagaSlug.toLowerCase();
+    final pageLabel = page?.toString() ?? 'default';
+    final sizeLabel = pageSize?.toString() ?? 'default';
+    return '$normalizedSlug|page:$pageLabel|size:$sizeLabel';
+  }
+
+  String _namaKey(String lembagaSlug, String nama) {
+    return '${lembagaSlug.toLowerCase()}|${nama.toLowerCase()}';
+  }
+
+  String _rangeKey(
+    String lembagaSlug,
+    int startYear,
+    int endYear, {
+    int? page,
+    int? pageSize,
+  }) {
+    final pageLabel = page?.toString() ?? 'default';
+    final sizeLabel = pageSize?.toString() ?? 'default';
+    return '${lembagaSlug.toLowerCase()}|$startYear-$endYear|page:$pageLabel|size:$sizeLabel';
+  }
+}

--- a/lib/screens/banner_test_screen.dart
+++ b/lib/screens/banner_test_screen.dart
@@ -25,8 +25,11 @@ class _BannerTestScreenState extends State<BannerTestScreen> {
   Future<void> _loadBanners() async {
     try {
       print('🧪 [BANNER_TEST] Loading banners for taman-kanak-kanak...');
-      final config = await _bannerManager.getBannerConfig('profil',
-          lembagaSlug: 'taman-kanak-kanak');
+      final config = await _bannerManager.getBannerConfig(
+        context,
+        'profil',
+        lembagaSlug: 'taman-kanak-kanak',
+      );
 
       print('🧪 [BANNER_TEST] Loaded banner config:');
       print('   - Top Banner: ${config.topBannerUrl}');

--- a/lib/screens/berita_al_ittifaqiah_screen.dart
+++ b/lib/screens/berita_al_ittifaqiah_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import '../widgets/top_banner.dart';
 import '../widgets/bottom_banner.dart';
 import '../widgets/responsive_wrapper.dart';
 import '../widgets/top_bar.dart';
 import '../models/informasi_al_ittifaqiah_model.dart';
-import '../repository/informasi_al_ittifaqiah_repository.dart';
+import '../providers/informasi_al_ittifaqiah_provider.dart';
 import 'content_screen.dart';
 
 class BeritaAlIttifaqiahScreen extends StatefulWidget {
@@ -16,8 +18,6 @@ class BeritaAlIttifaqiahScreen extends StatefulWidget {
 }
 
 class _BeritaAlIttifaqiahScreenState extends State<BeritaAlIttifaqiahScreen> {
-  final InformasiAlIttifaqiahRepository _repository =
-      InformasiAlIttifaqiahRepository();
   List<NewsItem>? _newsData;
   bool _isLoading = true;
   String? _errorMessage;
@@ -35,11 +35,13 @@ class _BeritaAlIttifaqiahScreenState extends State<BeritaAlIttifaqiahScreen> {
         _errorMessage = null;
       });
 
-      final informasiData = await _repository.fetchInformasiAlIttifaqiah();
+      final provider = context.read<InformasiAlIttifaqiahProvider>();
+      final informasiData = await provider.fetchInformasi(forceRefresh: true);
 
       setState(() {
         _newsData = informasiData?.news ?? [];
         _isLoading = false;
+        _errorMessage = provider.informasiState.errorMessage;
       });
 
       print('DEBUG: News data loaded: ${_newsData?.length ?? 0} items');

--- a/lib/screens/informasi_ittifaqiah_screen.dart
+++ b/lib/screens/informasi_ittifaqiah_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:markdown_widget/markdown_widget.dart';
+import 'package:provider/provider.dart';
 import 'package:pesantren_app/widgets/bottom_banner.dart';
 import 'package:pesantren_app/widgets/responsive_wrapper.dart';
 import 'package:pesantren_app/widgets/top_banner.dart';
@@ -12,7 +13,7 @@ import 'galeri_screen.dart';
 import 'blueprint_isci_dynamic_screen.dart';
 import '../models/lembaga_model.dart';
 import '../models/informasi_al_ittifaqiah_model.dart';
-import '../repository/informasi_al_ittifaqiah_repository.dart';
+import '../providers/informasi_al_ittifaqiah_provider.dart';
 import '../core/config/markdown_config.dart';
 
 class InformasiIttifaqiahScreen extends StatefulWidget {
@@ -24,8 +25,6 @@ class InformasiIttifaqiahScreen extends StatefulWidget {
 }
 
 class _InformasiIttifaqiahScreenState extends State<InformasiIttifaqiahScreen> {
-  final InformasiAlIttifaqiahRepository _repository =
-      InformasiAlIttifaqiahRepository();
   InformasiAlIttifaqiah? _informasiData;
   bool _isLoading = true;
   String? _errorMessage;
@@ -43,7 +42,9 @@ class _InformasiIttifaqiahScreenState extends State<InformasiIttifaqiahScreen> {
         _errorMessage = null;
       });
 
-      final data = await _repository.fetchInformasiAlIttifaqiah();
+      final provider = context.read<InformasiAlIttifaqiahProvider>();
+      final data = await provider.fetchInformasi(forceRefresh: true);
+      final state = provider.informasiState;
 
       // Debug print untuk melihat data yang dimuat
       print('DEBUG: Data loaded successfully');
@@ -60,6 +61,7 @@ class _InformasiIttifaqiahScreenState extends State<InformasiIttifaqiahScreen> {
       setState(() {
         _informasiData = data;
         _isLoading = false;
+        _errorMessage = state.errorMessage;
       });
     } catch (e) {
       print('DEBUG: Error loading data: $e');

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,17 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_login/flutter_login.dart';
-import '../repository/auth_repository.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
 import '../widgets/responsive_wrapper.dart';
 
 class LoginScreen extends StatelessWidget {
   const LoginScreen({Key? key}) : super(key: key);
 
   Duration get loginTime => const Duration(milliseconds: 2250);
-
-  Future<String?> _authUser(LoginData data) async {
-    final repo = AuthRepository();
-    return await repo.login(identifier: data.name, password: data.password);
-  }
 
   Future<String?> _recoverPassword(String name) async {
     await Future.delayed(loginTime);
@@ -20,6 +17,20 @@ class LoginScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Future<String?> _authUser(LoginData data) async {
+      final authProvider = context.read<AuthProvider>();
+      final success = await authProvider.login(
+        identifier: data.name,
+        password: data.password,
+      );
+
+      if (success) {
+        return null;
+      }
+
+      return authProvider.authError ?? 'Login gagal';
+    }
+
     return ResponsiveWrapper(
       child: Scaffold(
         body: Column(

--- a/lib/widgets/achievement_section.dart
+++ b/lib/widgets/achievement_section.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import 'achievement_item.dart';
-import '../repository/achievement_repository.dart';
 import '../models/achievement_model.dart';
+import '../providers/achievement_provider.dart';
 
 class AchievementSection extends StatefulWidget {
   const AchievementSection({super.key});
@@ -11,84 +13,87 @@ class AchievementSection extends StatefulWidget {
 }
 
 class _AchievementSectionState extends State<AchievementSection> {
-  final AchievementRepository _repository = AchievementRepository();
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<AchievementProvider>().fetchAchievements();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<AchievementModel>>(
-      future: _repository.fetchAchievements(),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(
-            child: Padding(
-              padding: EdgeInsets.all(20.0),
-              child: CircularProgressIndicator(),
-            ),
-          );
-        }
+    final provider = context.watch<AchievementProvider>();
+    final state = provider.achievementsState;
+    final List<AchievementModel> achievements = state.data ?? const [];
 
-        if (snapshot.hasError) {
-          return Center(
-            child: Padding(
-              padding: const EdgeInsets.all(20.0),
-              child: Column(
-                children: [
-                  const Icon(
-                    Icons.error_outline,
-                    color: Colors.red,
-                    size: 48,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Gagal memuat prestasi',
-                    style: TextStyle(
-                      color: Colors.red.shade700,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Periksa koneksi internet',
-                    style: TextStyle(
-                      color: Colors.grey.shade600,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
+    if (state.isLoading && !state.hasLoaded) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(20.0),
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (state.errorMessage != null && achievements.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            children: [
+              const Icon(
+                Icons.error_outline,
+                color: Colors.red,
+                size: 48,
               ),
-            ),
-          );
-        }
-
-        final achievements = snapshot.data ?? [];
-
-        if (achievements.isEmpty) {
-          return const Center(
-            child: Padding(
-              padding: EdgeInsets.all(20.0),
-              child: Text(
-                'Belum ada prestasi yang tersedia',
+              const SizedBox(height: 8),
+              Text(
+                'Gagal memuat prestasi',
                 style: TextStyle(
-                  color: Colors.grey,
-                  fontSize: 14,
+                  color: Colors.red.shade700,
+                  fontWeight: FontWeight.w600,
                 ),
               ),
-            ),
-          );
-        }
+              const SizedBox(height: 4),
+              Text(
+                'Periksa koneksi internet',
+                style: TextStyle(
+                  color: Colors.grey.shade600,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
 
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ...achievements
-                .map((achievement) => AchievementItem(
-                      achievement: achievement,
-                    ))
-                .toList(),
-            const SizedBox(height: 72),
-          ],
-        );
-      },
+    if (achievements.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(20.0),
+          child: Text(
+            'Belum ada prestasi yang tersedia',
+            style: TextStyle(
+              color: Colors.grey,
+              fontSize: 14,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ...achievements
+            .map((achievement) => AchievementItem(
+                  achievement: achievement,
+                ))
+            .toList(),
+        const SizedBox(height: 72),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- introduce reusable provider layer for achievements, banners, auth, lembaga, santri, staff, attendance, sliders, and informasi
- refactor screens and utilities to consume providers instead of directly instantiating repositories while preserving UI behaviour
- update application bootstrap to register new providers and keep state-driven fetch logic consistent

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e33437fca4833192b87838fc34cbb9