### PR TITLE
Refactor screens to support varied heights

### DIFF
--- a/lib/screens/alumni_screen.dart
+++ b/lib/screens/alumni_screen.dart
@@ -242,50 +242,58 @@ class _AlumniScreenState extends State<AlumniScreen> {
 
     return Scaffold(
       backgroundColor: AppColors.primaryGreen,
-      body: Column(
-        children: [
-          if (_errorMessage != null)
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
-              color: Colors.orange.shade100,
-              child: Row(
-                children: [
-                  Icon(Icons.info_outline,
-                      color: Colors.orange.shade700, size: 20),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      _errorMessage!,
-                      style: TextStyle(
-                          color: Colors.orange.shade900, fontSize: 12),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+      body: RefreshIndicator(
+        color: AppColors.primaryGreen,
+        onRefresh: () => _fetchAlumniData(tahunMasuk: selectedYear),
+        child: CustomScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          slivers: [
+            if (_errorMessage != null)
+              SliverToBoxAdapter(
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  color: Colors.orange.shade100,
+                  child: Row(
+                    children: [
+                      Icon(Icons.info_outline,
+                          color: Colors.orange.shade700, size: 20),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          _errorMessage!,
+                          style: TextStyle(
+                              color: Colors.orange.shade900, fontSize: 12),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
-          _buildHeader(),
-          Expanded(
-            child: Container(
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.only(
-                  topLeft: Radius.circular(30),
-                  topRight: Radius.circular(30),
                 ),
               ),
-              child: Column(
-                children: [
-                  _buildFilters(),
-                  _buildAlumniCount(),
-                  Expanded(child: _buildAlumniList()),
-                ],
+            SliverToBoxAdapter(child: _buildHeader()),
+            SliverToBoxAdapter(
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(30),
+                    topRight: Radius.circular(30),
+                  ),
+                ),
+                child: Column(
+                  children: [
+                    _buildFilters(),
+                    _buildAlumniCount(),
+                    _buildAlumniList(),
+                    const SizedBox(height: 24),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -569,20 +577,18 @@ class _AlumniScreenState extends State<AlumniScreen> {
             ),
           ),
           const SizedBox(height: 12),
-          Expanded(
-            child: filteredAlumni.isEmpty
-                ? _buildEmptyState()
-                : RefreshIndicator(
-                    onRefresh: _fetchAlumniData,
-                    child: ListView.builder(
-                      itemCount: filteredAlumni.length,
-                      itemBuilder: (context, index) {
-                        final alumni = filteredAlumni[index];
-                        return _buildAlumniCard(alumni, index);
-                      },
-                    ),
-                  ),
-          ),
+          if (filteredAlumni.isEmpty)
+            SizedBox(height: 200, child: _buildEmptyState())
+          else
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: filteredAlumni.length,
+              itemBuilder: (context, index) {
+                final alumni = filteredAlumni[index];
+                return _buildAlumniCard(alumni, index);
+              },
+            ),
         ],
       ),
     );

--- a/lib/screens/berita_al_ittifaqiah_screen.dart
+++ b/lib/screens/berita_al_ittifaqiah_screen.dart
@@ -59,14 +59,23 @@ class _BeritaAlIttifaqiahScreenState extends State<BeritaAlIttifaqiahScreen> {
     return ResponsiveWrapper(
       child: Scaffold(
         appBar: const TopBar(title: 'Berita Al-Ittifaqiah'),
-        body: Column(
-          children: [
-            const TopBanner(assetPath: 'assets/banners/top.png'),
-            const SizedBox(height: 16),
-            Expanded(
-              child: _buildBody(),
-            ),
-          ],
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const TopBanner(assetPath: 'assets/banners/top.png'),
+                    const SizedBox(height: 16),
+                    _buildBody(embedded: true),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+              ),
+            );
+          },
         ),
         bottomNavigationBar:
             const BottomBanner(assetPath: 'assets/banners/bottom.png'),
@@ -74,80 +83,101 @@ class _BeritaAlIttifaqiahScreenState extends State<BeritaAlIttifaqiahScreen> {
     );
   }
 
-  Widget _buildBody() {
+  Widget _buildBody({bool embedded = false}) {
     if (_isLoading) {
-      return const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircularProgressIndicator(),
-            SizedBox(height: 16),
-            Text(
-              'Memuat berita...',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey,
-              ),
+      final child = Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          CircularProgressIndicator(),
+          SizedBox(height: 16),
+          Text(
+            'Memuat berita...',
+            style: TextStyle(
+              fontSize: 16,
+              color: Colors.grey,
             ),
-          ],
-        ),
+          ),
+        ],
       );
+
+      if (embedded) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Center(child: child),
+        );
+      }
+
+      return Center(child: child);
     }
 
     if (_errorMessage != null) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(
-              Icons.error_outline,
-              size: 64,
+      final child = Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(
+            Icons.error_outline,
+            size: 64,
+            color: Colors.red,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            _errorMessage!,
+            style: const TextStyle(
+              fontSize: 16,
               color: Colors.red,
             ),
-            const SizedBox(height: 16),
-            Text(
-              _errorMessage!,
-              style: const TextStyle(
-                fontSize: 16,
-                color: Colors.red,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: _loadNewsData,
-              child: const Text('Coba Lagi'),
-            ),
-          ],
-        ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: _loadNewsData,
+            child: const Text('Coba Lagi'),
+          ),
+        ],
       );
+
+      if (embedded) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Center(child: child),
+        );
+      }
+
+      return Center(child: child);
     }
 
     if (_newsData == null || _newsData!.isEmpty) {
-      return const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.article_outlined,
-              size: 64,
+      const child = Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.article_outlined,
+            size: 64,
+            color: Colors.grey,
+          ),
+          SizedBox(height: 16),
+          Text(
+            'Tidak ada berita tersedia',
+            style: TextStyle(
+              fontSize: 16,
               color: Colors.grey,
             ),
-            SizedBox(height: 16),
-            Text(
-              'Tidak ada berita tersedia',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey,
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       );
+
+      if (embedded) {
+        return const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16),
+          child: Center(child: child),
+        );
+      }
+
+      return const Center(child: child);
     }
 
-    return ListView.builder(
-      padding: const EdgeInsets.all(16),
+    final listView = ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       itemCount: _newsData!.length,
       itemBuilder: (context, index) {
         final newsItem = _newsData![index];
@@ -170,6 +200,40 @@ class _BeritaAlIttifaqiahScreenState extends State<BeritaAlIttifaqiahScreen> {
         );
       },
     );
+
+    if (embedded) {
+      return ListView.builder(
+        padding: EdgeInsets.zero,
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: _newsData!.length,
+        itemBuilder: (context, index) {
+          final newsItem = _newsData![index];
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: _BeritaCard(
+              title: newsItem.title,
+              thumbnail: newsItem.thumbnailUrl,
+              content: newsItem.content,
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ContentScreen(
+                      title: newsItem.title,
+                      markdownContent: newsItem.content,
+                      type: ContentScreenType.minimal,
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      );
+    }
+
+    return listView;
   }
 }
 

--- a/lib/screens/blueprint_isci__screen.dart
+++ b/lib/screens/blueprint_isci__screen.dart
@@ -19,69 +19,70 @@ class BlueprintIsciScreen extends StatelessWidget {
     return ResponsiveWrapper(
       child: Scaffold(
         appBar: const TopBar(title: 'BluePrint ISCI'),
-        body: Column(
-          children: [
-            const TopBanner(assetPath: 'assets/banners/top.png'),
-            const SizedBox(height: 16),
-            Expanded(
-              child: blueprintItems.isEmpty
-                  ? const Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(
-                            Icons.architecture_outlined,
-                            size: 64,
-                            color: Colors.grey,
-                          ),
-                          SizedBox(height: 16),
-                          Text(
-                            'Tidak ada data BluePrint ISCI',
-                            style: TextStyle(
-                              fontSize: 16,
-                              color: Colors.grey,
-                            ),
-                          ),
-                        ],
+        body: CustomScrollView(
+          slivers: [
+            const SliverToBoxAdapter(
+                child: TopBanner(assetPath: 'assets/banners/top.png')),
+            const SliverToBoxAdapter(child: SizedBox(height: 16)),
+            if (blueprintItems.isEmpty)
+              const SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.architecture_outlined,
+                        size: 64,
+                        color: Colors.grey,
                       ),
-                    )
-                  : SingleChildScrollView(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const SectionHeader(
-                            title: 'BluePrint ISCI Al-Ittifaqiah',
-                          ),
-                          const Text(
-                            'Rencana Pembangunan Masa Depan',
-                            style: TextStyle(
-                              fontSize: 14,
-                              color: Colors.grey,
-                            ),
-                          ),
-                          const SizedBox(height: 16),
-                          GridView.builder(
-                            shrinkWrap: true,
-                            physics: const NeverScrollableScrollPhysics(),
-                            gridDelegate:
-                                const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 1,
-                              childAspectRatio: 1.2,
-                              crossAxisSpacing: 12,
-                              mainAxisSpacing: 12,
-                            ),
-                            itemCount: blueprintItems.length,
-                            itemBuilder: (context, index) {
-                              final item = blueprintItems[index];
-                              return _buildBlueprintCard(context, item);
-                            },
-                          ),
-                          const SizedBox(height: 16),
-                        ],
+                      SizedBox(height: 16),
+                      Text(
+                        'Tidak ada data BluePrint ISCI',
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate([
+                    const SectionHeader(
+                      title: 'BluePrint ISCI Al-Ittifaqiah',
+                    ),
+                    const Text(
+                      'Rencana Pembangunan Masa Depan',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey,
                       ),
                     ),
-            ),
+                    const SizedBox(height: 16),
+                    GridView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 1,
+                        childAspectRatio: 1.2,
+                        crossAxisSpacing: 12,
+                        mainAxisSpacing: 12,
+                      ),
+                      itemCount: blueprintItems.length,
+                      itemBuilder: (context, index) {
+                        final item = blueprintItems[index];
+                        return _buildBlueprintCard(context, item);
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                  ]),
+                ),
           ],
         ),
         bottomNavigationBar:

--- a/lib/screens/contact_screen.dart
+++ b/lib/screens/contact_screen.dart
@@ -29,19 +29,31 @@ class ContactScreen extends StatelessWidget {
         backgroundColor: const Color(0xFF2E7D32),
         foregroundColor: Colors.white,
       ),
-      body: Center(
-        child: Column(children: [
-          // Use API banner if available, otherwise use default banner
-          if (bannerConfig != null && bannerConfig.hasTopBanner)
-            BannerWidget(bannerConfig: bannerConfig)
-          else
-            const TopBanner(assetPath: 'assets/banners/top.png'),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final content = Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Use API banner if available, otherwise use default banner
+              if (bannerConfig != null && bannerConfig.hasTopBanner)
+                BannerWidget(bannerConfig: bannerConfig)
+              else
+                const TopBanner(assetPath: 'assets/banners/top.png'),
 
-          const SizedBox(height: 20),
+              const SizedBox(height: 20),
 
-          // Pass contact data from API to ContactPanel
-          ContactPanel(kontakData: kontakData)
-        ]),
+              // Pass contact data from API to ContactPanel
+              ContactPanel(kontakData: kontakData)
+            ],
+          );
+
+          return SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(child: content),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/screens/content_screen.dart
+++ b/lib/screens/content_screen.dart
@@ -56,7 +56,7 @@ class ContentScreen extends StatelessWidget {
 
         // Gunakan Expanded sederhana
         Expanded(
-          child: Container(
+          child: SingleChildScrollView(
             padding: const EdgeInsets.all(20.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/detail_screen.dart
+++ b/lib/screens/detail_screen.dart
@@ -70,98 +70,106 @@ class _DetailScreenState extends State<DetailScreen> {
         appBar: AppBar(
           title: Text(widget.title),
         ),
-        body: Column(
-          children: [
-            (lembaga != null && bannerConfig.hasTopBanner)
-                ? BannerWidget(
-                    bannerConfig: bannerConfig,
-                    isTopBanner: true,
-                    height: 150,
-                  )
-                : TopBanner(
-                    assetPath: 'assets/banners/top.png',
-                    height: 150,
-                  ),
-            if (isLoadingData)
-              Container(
-                padding: const EdgeInsets.all(12),
-                margin: const EdgeInsets.symmetric(horizontal: 16),
-                decoration: BoxDecoration(
-                  color: Colors.blue.shade50,
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.blue.shade200),
-                ),
-                child: Row(
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
-                        'Memuat data ${widget.title}...',
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: Colors.blue.shade700,
-                          fontWeight: FontWeight.w500,
+                    (lembaga != null && bannerConfig.hasTopBanner)
+                        ? BannerWidget(
+                            bannerConfig: bannerConfig,
+                            isTopBanner: true,
+                            height: 150,
+                          )
+                        : TopBanner(
+                            assetPath: 'assets/banners/top.png',
+                            height: 150,
+                          ),
+                    if (isLoadingData)
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        margin: const EdgeInsets.symmetric(horizontal: 16),
+                        decoration: BoxDecoration(
+                          color: Colors.blue.shade50,
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.blue.shade200),
+                        ),
+                        child: Row(
+                          children: [
+                            const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                'Memuat data ${widget.title}...',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: Colors.blue.shade700,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                    ),
-                  ],
-                ),
-              ),
-            if (loadingError != null && !isLoadingData)
-              Container(
-                padding: const EdgeInsets.all(12),
-                margin: const EdgeInsets.symmetric(horizontal: 16),
-                decoration: BoxDecoration(
-                  color: Colors.orange.shade50,
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.orange.shade200),
-                ),
-                child: Row(
-                  children: [
-                    Icon(Icons.warning, color: Colors.orange.shade700),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Gagal memuat data online',
-                            style: TextStyle(
-                              fontSize: 14,
-                              color: Colors.orange.shade700,
-                              fontWeight: FontWeight.w500,
+                    if (loadingError != null && !isLoadingData)
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        margin: const EdgeInsets.symmetric(horizontal: 16),
+                        decoration: BoxDecoration(
+                          color: Colors.orange.shade50,
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.orange.shade200),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(Icons.warning, color: Colors.orange.shade700),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Gagal memuat data online',
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      color: Colors.orange.shade700,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                  Text(
+                                    loadingError,
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      color: Colors.orange.shade600,
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                          Text(
-                            loadingError,
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: Colors.orange.shade600,
-                            ),
-                          ),
-                        ],
+                          ],
+                        ),
+                      ),
+                    Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: DetailLayout(
+                        title: widget.title,
+                        menuItems: widget.menuItems,
+                        lembagaSlug: _lembagaSlug,
+                        cachedLembaga: lembaga,
                       ),
                     ),
                   ],
                 ),
               ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: DetailLayout(
-                  title: widget.title,
-                  menuItems: widget.menuItems,
-                  lembagaSlug: _lembagaSlug,
-                  cachedLembaga: lembaga,
-                ),
-              ),
-            ),
-          ],
+            );
+          },
         ),
         bottomNavigationBar:
             (lembaga != null && bannerConfig.hasBottomBanner)

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -122,103 +122,107 @@ class _HomeScreenState extends State<HomeScreen> {
           automaticallyImplyLeading: false,
           isHomeScreen: true,
         ),
-        body: Column(
-          children: [
-            // Carousel dengan Provider
-            _buildSlider(),
-            Expanded(
-              child: Column(
-                children: [
-                  Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 1, vertical: 1),
-                    child: Material(
-                      elevation: 12,
-                      borderRadius: BorderRadius.circular(12),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(vertical: 24),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            MenuRow(
-                              items: [HomeScreen._menuItems[0]],
-                              buttonSize: 48,
-                              onTap: (title) {
-                                Navigator.pushNamed(
-                                  context,
-                                  AppRouter.menu,
-                                  arguments: MenuScreenArgs(title: title),
-                                );
-                              },
-                            ),
-                            SizedBox(height: 8),
-                            MenuRow(
-                              items: HomeScreen._menuItems.sublist(1, 4),
-                              buttonSize: 48,
-                              onTap: (title) {
-                                Navigator.pushNamed(
-                                  context,
-                                  AppRouter.menu,
-                                  arguments: MenuScreenArgs(title: title),
-                                );
-                              },
-                            ),
-                            SizedBox(height: 8),
-                            MenuRow(
-                              items: HomeScreen._menuItems.sublist(4, 7),
-                              buttonSize: 48,
-                              onTap: (title) {
-                                Navigator.pushNamed(
-                                  context,
-                                  AppRouter.menu,
-                                  arguments: MenuScreenArgs(title: title),
-                                );
-                              },
-                            ),
-                            SizedBox(height: 8),
-                            MenuRow(
-                              items: HomeScreen._menuItems.sublist(7, 10),
-                              buttonSize: 48,
-                              onTap: (title) {
-                                if (title == 'DONASI') {
-                                  Navigator.pushNamed(
-                                      context, AppRouter.donasi);
-                                } else if (title == 'INFORMASI') {
-                                  Navigator.pushNamed(
-                                      context, AppRouter.informasi);
-                                } else {
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _buildSlider(),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 1, vertical: 1),
+                      child: Material(
+                        elevation: 12,
+                        borderRadius: BorderRadius.circular(12),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(vertical: 24),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              MenuRow(
+                                items: [HomeScreen._menuItems[0]],
+                                buttonSize: 48,
+                                onTap: (title) {
                                   Navigator.pushNamed(
                                     context,
                                     AppRouter.menu,
                                     arguments: MenuScreenArgs(title: title),
                                   );
-                                }
-                              },
-                            ),
-                          ],
+                                },
+                              ),
+                              const SizedBox(height: 8),
+                              MenuRow(
+                                items: HomeScreen._menuItems.sublist(1, 4),
+                                buttonSize: 48,
+                                onTap: (title) {
+                                  Navigator.pushNamed(
+                                    context,
+                                    AppRouter.menu,
+                                    arguments: MenuScreenArgs(title: title),
+                                  );
+                                },
+                              ),
+                              const SizedBox(height: 8),
+                              MenuRow(
+                                items: HomeScreen._menuItems.sublist(4, 7),
+                                buttonSize: 48,
+                                onTap: (title) {
+                                  Navigator.pushNamed(
+                                    context,
+                                    AppRouter.menu,
+                                    arguments: MenuScreenArgs(title: title),
+                                  );
+                                },
+                              ),
+                              const SizedBox(height: 8),
+                              MenuRow(
+                                items: HomeScreen._menuItems.sublist(7, 10),
+                                buttonSize: 48,
+                                onTap: (title) {
+                                  if (title == 'DONASI') {
+                                    Navigator.pushNamed(
+                                        context, AppRouter.donasi);
+                                  } else if (title == 'INFORMASI') {
+                                    Navigator.pushNamed(
+                                        context, AppRouter.informasi);
+                                  } else {
+                                    Navigator.pushNamed(
+                                      context,
+                                      AppRouter.menu,
+                                      arguments: MenuScreenArgs(title: title),
+                                    );
+                                  }
+                                },
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 6),
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: SectionHeader(
-                        title: 'Prestasi dan Penghargaan',
-                        backgroundColor: Colors.green.shade700,
-                        textColor: Colors.white,
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 6),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: SectionHeader(
+                          title: 'Prestasi dan Penghargaan',
+                          backgroundColor: Colors.green.shade700,
+                          textColor: Colors.white,
+                        ),
                       ),
                     ),
-                  ),
-                  // Achievement section dengan API call
-                  const Expanded(
-                    child: AchievementSection(),
-                  ),
-                ],
+                    const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: AchievementSection(),
+                    ),
+                    const SizedBox(height: 72),
+                  ],
+                ),
               ),
-            ),
-          ],
+            );
+          },
         ),
         bottomNavigationBar:
             const BottomBanner(assetPath: 'assets/banners/bottom.png'),

--- a/lib/screens/informasi_ittifaqiah_screen.dart
+++ b/lib/screens/informasi_ittifaqiah_screen.dart
@@ -102,208 +102,202 @@ class _InformasiIttifaqiahScreenState extends State<InformasiIttifaqiahScreen> {
     return ResponsiveWrapper(
       child: Scaffold(
         appBar: const TopBar(title: 'Informasi Al-Ittifaqiah'),
-        body: Column(
-          children: [
-            const TopBanner(assetPath: 'assets/banners/top.png'),
-            const SizedBox(height: 16),
-            Expanded(
-              child: _isLoading
-                  ? const Center(child: CircularProgressIndicator())
-                  : _errorMessage != null
-                      ? Center(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Icon(
-                                Icons.error_outline,
-                                size: 64,
-                                color: Colors.red[300],
-                              ),
-                              const SizedBox(height: 16),
-                              Text(
-                                _errorMessage!,
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                  fontSize: 16,
-                                  color: Colors.red,
-                                ),
-                              ),
-                              const SizedBox(height: 16),
-                              ElevatedButton(
-                                onPressed: _loadData,
-                                child: const Text('Coba Lagi'),
-                              ),
-                            ],
-                          ),
-                        )
-                      : ListView(
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          children: [
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'Profil Al-Ittifaqiah',
-                              onTap: () {
-                                if (_informasiData?.hasProfilContent() ==
-                                    true) {
-                                  Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (context) => _ProfilScreen(
-                                        profilMd: _informasiData!.profilMd!,
-                                      ),
-                                    ),
-                                  );
-                                } else {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    const SnackBar(
-                                      content:
-                                          Text('Data profil tidak tersedia'),
-                                    ),
-                                  );
-                                }
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'Berita Al-Ittifaqiah',
-                              onTap: () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        const BeritaAlIttifaqiahScreen(),
-                                  ),
-                                );
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'Jumlah Santri Al-Ittifaqiah',
-                              onTap: () {
-                                final santriData = _informasiData?.santri ?? [];
-                                print(
-                                    'DEBUG: Santri data: ${santriData.length} records');
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        StatisticsScreen.santri(santriData),
-                                  ),
-                                );
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'Jumlah SDM Al-Ittifaqiah',
-                              onTap: () {
-                                final sdmData = _informasiData?.sdm ?? [];
-                                print(
-                                    'DEBUG: SDM data: ${sdmData.length} records');
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        StatisticsScreen.sdm(sdmData),
-                                  ),
-                                );
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'Jumlah Alumni Al-Ittifaqiah',
-                              onTap: () {
-                                final alumniData = _informasiData?.alumni ?? [];
-                                print(
-                                    'DEBUG: Alumni data: ${alumniData.length} records');
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        StatisticsScreen.alumni(alumniData),
-                                  ),
-                                );
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'Galeri Luar Negeri',
-                              onTap: () {
-                                final galeriData =
-                                    _informasiData?.galeriLuarNegeri ?? [];
-                                print(
-                                    'DEBUG: Galeri Luar Negeri data: ${galeriData.length} items');
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => GaleriScreen(
-                                      title: 'Galeri Luar Negeri Al-Ittifaqiah',
-                                      lembaga: _createLembagaFromGaleri(
-                                        galeriData,
-                                        'Luar Negeri Al-Ittifaqiah',
-                                        'galeri-luar-negeri',
-                                      ),
-                                      crossAxisCount: 1,
-                                      showTabs: false,
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'Galeri Tamu',
-                              onTap: () {
-                                final galeriData =
-                                    _informasiData?.galeriTamu ?? [];
-                                print(
-                                    'DEBUG: Galeri Tamu data: ${galeriData.length} items');
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => GaleriScreen(
-                                      title: 'Galeri Tamu',
-                                      lembaga: _createLembagaFromGaleri(
-                                        galeriData,
-                                        'Tamu',
-                                        'galeri-tamu',
-                                      ),
-                                      crossAxisCount: 1,
-                                      showTabs: false,
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            ReusableListTileWidget(
-                              value: null,
-                              titleText: 'BluePrint ISCI',
-                              onTap: () {
-                                final bluePrintData =
-                                    _informasiData?.bluePrintISCI ?? [];
-                                print(
-                                    'DEBUG: BluePrint ISCI data: ${bluePrintData.length} items');
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        BlueprintIsciScreen(
-                                      blueprintItems: bluePrintData,
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                            const SizedBox(height: 16),
-                          ],
+        body: CustomScrollView(
+          slivers: [
+            const SliverToBoxAdapter(child: TopBanner(assetPath: 'assets/banners/top.png')),
+            const SliverToBoxAdapter(child: SizedBox(height: 16)),
+            if (_isLoading)
+              const SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(child: CircularProgressIndicator()),
+              )
+            else if (_errorMessage != null)
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.error_outline,
+                          size: 64,
+                          color: Colors.red[300],
                         ),
-            ),
+                        const SizedBox(height: 16),
+                        Text(
+                          _errorMessage!,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            color: Colors.red,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        ElevatedButton(
+                          onPressed: _loadData,
+                          child: const Text('Coba Lagi'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              )
+            else
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate([
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'Profil Al-Ittifaqiah',
+                      onTap: () {
+                        if (_informasiData?.hasProfilContent() == true) {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => _ProfilScreen(
+                                profilMd: _informasiData!.profilMd!,
+                              ),
+                            ),
+                          );
+                        } else {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Data profil tidak tersedia'),
+                            ),
+                          );
+                        }
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'Berita Al-Ittifaqiah',
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const BeritaAlIttifaqiahScreen(),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'Jumlah Santri Al-Ittifaqiah',
+                      onTap: () {
+                        final santriData = _informasiData?.santri ?? [];
+                        print('DEBUG: Santri data: ${santriData.length} records');
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => StatisticsScreen.santri(santriData),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'Jumlah SDM Al-Ittifaqiah',
+                      onTap: () {
+                        final sdmData = _informasiData?.sdm ?? [];
+                        print('DEBUG: SDM data: ${sdmData.length} records');
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => StatisticsScreen.sdm(sdmData),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'Jumlah Alumni Al-Ittifaqiah',
+                      onTap: () {
+                        final alumniData = _informasiData?.alumni ?? [];
+                        print('DEBUG: Alumni data: ${alumniData.length} records');
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => StatisticsScreen.alumni(alumniData),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'Galeri Luar Negeri',
+                      onTap: () {
+                        final galeriData = _informasiData?.galeriLuarNegeri ?? [];
+                        print('DEBUG: Galeri Luar Negeri data: ${galeriData.length} items');
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => GaleriScreen(
+                              title: 'Galeri Luar Negeri Al-Ittifaqiah',
+                              lembaga: _createLembagaFromGaleri(
+                                galeriData,
+                                'Luar Negeri Al-Ittifaqiah',
+                                'galeri-luar-negeri',
+                              ),
+                              crossAxisCount: 1,
+                              showTabs: false,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'Galeri Tamu',
+                      onTap: () {
+                        final galeriData = _informasiData?.galeriTamu ?? [];
+                        print('DEBUG: Galeri Tamu data: ${galeriData.length} items');
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => GaleriScreen(
+                              title: 'Galeri Tamu',
+                              lembaga: _createLembagaFromGaleri(
+                                galeriData,
+                                'Tamu',
+                                'galeri-tamu',
+                              ),
+                              crossAxisCount: 1,
+                              showTabs: false,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ReusableListTileWidget(
+                      value: null,
+                      titleText: 'BluePrint ISCI',
+                      onTap: () {
+                        final bluePrintData = _informasiData?.bluePrintISCI ?? [];
+                        print('DEBUG: BluePrint ISCI data: ${bluePrintData.length} items');
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => BlueprintIsciScreen(
+                              blueprintItems: bluePrintData,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 24),
+                  ]),
+                ),
+              ),
           ],
         ),
         bottomNavigationBar:
@@ -322,24 +316,21 @@ class _ProfilScreen extends StatelessWidget {
     return ResponsiveWrapper(
       child: Scaffold(
         appBar: const TopBar(title: 'Profil Al-Ittifaqiah'),
-        body: Column(
-          children: [
-            const TopBanner(assetPath: 'assets/banners/top.png'),
-            const SizedBox(height: 16),
-            Expanded(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Display markdown content from API with proper formatting
-                    MarkdownBlock(
-                      data: profilMd,
-                      config: AppMarkdownConfig.defaultConfig,
-                    ),
-                    const SizedBox(height: 16),
-                  ],
-                ),
+        body: CustomScrollView(
+          slivers: [
+            const SliverToBoxAdapter(
+                child: TopBanner(assetPath: 'assets/banners/top.png')),
+            const SliverToBoxAdapter(child: SizedBox(height: 16)),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverList(
+                delegate: SliverChildListDelegate([
+                  MarkdownBlock(
+                    data: profilMd,
+                    config: AppMarkdownConfig.defaultConfig,
+                  ),
+                  const SizedBox(height: 16),
+                ]),
               ),
             ),
           ],

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -33,29 +33,36 @@ class LoginScreen extends StatelessWidget {
 
     return ResponsiveWrapper(
       child: Scaffold(
-        body: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Expanded(
-              child: FlutterLogin(
-                title: 'Al Ittifaqiah',
-                onLogin: _authUser,
-                onRecoverPassword: _recoverPassword,
-                onSubmitAnimationCompleted: () {
-                  Navigator.of(context).pushReplacementNamed('/home');
-                },
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    FlutterLogin(
+                      title: 'Al Ittifaqiah',
+                      onLogin: _authUser,
+                      onRecoverPassword: _recoverPassword,
+                      onSubmitAnimationCompleted: () {
+                        Navigator.of(context).pushReplacementNamed('/home');
+                      },
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 16.0, top: 8.0),
+                      child: TextButton(
+                        onPressed: () {
+                          Navigator.of(context).pushReplacementNamed('/home');
+                        },
+                        child: const Text('Login as Guest'),
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 16.0),
-              child: TextButton(
-                onPressed: () {
-                  Navigator.of(context).pushReplacementNamed('/home');
-                },
-                child: Text('Login as Guest'),
-              ),
-            ),
-          ],
+            );
+          },
         ),
       ),
     );

--- a/lib/screens/menu_screen.dart
+++ b/lib/screens/menu_screen.dart
@@ -49,143 +49,163 @@ class _MenuScreenState extends State<MenuScreen> {
     return ResponsiveWrapper(
       child: Scaffold(
         appBar: TopBar(title: widget.args.title),
-        body: Column(
-          children: [
-            // Use banner from API if available, fallback to assets
-            isLoadingBanner
-                ? Container(
-                    height: 120,
-                    child: Center(child: CircularProgressIndicator()),
-                  )
-                : TopBanner(
-                    imageUrl: banner?.resolvedTopBannerUrl,
-                    assetPath: 'assets/banners/top.png', // Fallback
-                  ),
-            SizedBox(height: 20),
-            Expanded(
-              child: Builder(
-                builder: (context) {
-                  if (widget.menuData is Map<String, dynamic>) {
-                    final keys = widget.menuData.keys.toList();
-                    return ListView.builder(
-                      itemCount: keys.length,
-                      itemBuilder: (context, index) {
-                        final key = keys[index];
-                        return ReusableListTileWidget(
-                          value: null,
-                          titleText: key,
-                          onTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => MenuScreen(
-                                  args: MenuScreenArgs(title: key),
-                                  menuData: widget.menuData[key],
-                                ),
-                              ),
-                            );
-                          },
-                        );
-                      },
-                    );
-                  } else if (widget.menuData is List) {
-                    // Cek apakah List berisi Map (menu dengan warna)
-                    if (widget.menuData.isNotEmpty &&
-                        widget.menuData.first is Map) {
-                      return ListView.builder(
-                        itemCount: widget.menuData.length,
-                        itemBuilder: (context, index) {
-                          final item =
-                              widget.menuData[index] as Map<String, dynamic>;
-                          final title = item['title'] ?? '';
-                          final indexBackgroundColor =
-                              item['indexBackgroundColor'] != null
-                                  ? Color(item['indexBackgroundColor'])
-                                  : null;
-                          final titleTextBackgroundColor =
-                              item['titleTextBackgroundColor'] != null
-                                  ? Color(item['titleTextBackgroundColor'])
-                                  : null;
-                          Widget tile = ReusableListTileWidget(
-                            value: null,
-                            titleText: title,
-                            indexBackgroundColor: indexBackgroundColor,
-                            titleTextBackgroundColor: titleTextBackgroundColor,
-                            onTap: () {
-                              // Jika item adalah label (Formal/Non Formal), tidak navigasi
-                              if (title == 'Formal' || title == 'Non Formal')
-                                return;
-                              final isPenyelenggara = widget.args.title ==
-                                  'Organ Penyelenggara Pendidikan Formal';
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) => DetailScreen(
-                                    title: title,
-                                    menuItems: isPenyelenggara
-                                        ? menuItemsJenis2
-                                        : menuItemsJenis1,
-                                  ),
-                                ),
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // Use banner from API if available, fallback to assets
+                    isLoadingBanner
+                        ? SizedBox(
+                            height: 120,
+                            child: Center(child: CircularProgressIndicator()),
+                          )
+                        : TopBanner(
+                            imageUrl: banner?.resolvedTopBannerUrl,
+                            assetPath: 'assets/banners/top.png', // Fallback
+                          ),
+                    const SizedBox(height: 20),
+                    Builder(
+                      builder: (context) {
+                        if (widget.menuData is Map<String, dynamic>) {
+                          final keys = widget.menuData.keys.toList();
+                          return ListView.builder(
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            itemCount: keys.length,
+                            itemBuilder: (context, index) {
+                              final key = keys[index];
+                              return ReusableListTileWidget(
+                                value: null,
+                                titleText: key,
+                                onTap: () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => MenuScreen(
+                                        args: MenuScreenArgs(title: key),
+                                        menuData: widget.menuData[key],
+                                      ),
+                                    ),
+                                  );
+                                },
                               );
                             },
                           );
-                          if (title != 'Formal' && title != 'Non Formal') {
-                            tile = Padding(
-                              padding: const EdgeInsets.only(left: 60.0),
-                              child: tile,
+                        } else if (widget.menuData is List) {
+                          // Cek apakah List berisi Map (menu dengan warna)
+                          if (widget.menuData.isNotEmpty &&
+                              widget.menuData.first is Map) {
+                            return ListView.builder(
+                              shrinkWrap: true,
+                              physics: const NeverScrollableScrollPhysics(),
+                              itemCount: widget.menuData.length,
+                              itemBuilder: (context, index) {
+                                final item = widget.menuData[index]
+                                    as Map<String, dynamic>;
+                                final title = item['title'] ?? '';
+                                final indexBackgroundColor =
+                                    item['indexBackgroundColor'] != null
+                                        ? Color(item['indexBackgroundColor'])
+                                        : null;
+                                final titleTextBackgroundColor =
+                                    item['titleTextBackgroundColor'] != null
+                                        ? Color(item['titleTextBackgroundColor'])
+                                        : null;
+                                Widget tile = ReusableListTileWidget(
+                                  value: null,
+                                  titleText: title,
+                                  indexBackgroundColor: indexBackgroundColor,
+                                  titleTextBackgroundColor:
+                                      titleTextBackgroundColor,
+                                  onTap: () {
+                                    // Jika item adalah label (Formal/Non Formal), tidak navigasi
+                                    if (title == 'Formal' ||
+                                        title == 'Non Formal') {
+                                      return;
+                                    }
+                                    final isPenyelenggara = widget.args.title ==
+                                        'Organ Penyelenggara Pendidikan Formal';
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (context) => DetailScreen(
+                                          title: title,
+                                          menuItems: isPenyelenggara
+                                              ? menuItemsJenis2
+                                              : menuItemsJenis1,
+                                        ),
+                                      ),
+                                    );
+                                  },
+                                );
+                                if (title != 'Formal' &&
+                                    title != 'Non Formal') {
+                                  tile = Padding(
+                                    padding:
+                                        const EdgeInsets.only(left: 60.0),
+                                    child: tile,
+                                  );
+                                }
+                                return tile;
+                              },
                             );
+                          } else if (widget.menuData.isNotEmpty &&
+                              widget.menuData.first is String) {
+                            // Fallback jika masih List<String> atau List menu bercabang
+                            return ListView.builder(
+                              shrinkWrap: true,
+                              physics: const NeverScrollableScrollPhysics(),
+                              itemCount: widget.menuData.length,
+                              itemBuilder: (context, index) {
+                                final item = widget.menuData[index];
+                                return ReusableListTileWidget(
+                                  value: null,
+                                  titleText: item.toString(),
+                                  onTap: () {
+                                    if (item is List) {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) => MenuScreen(
+                                            args: MenuScreenArgs(
+                                                title: item.toString()),
+                                            menuData: item,
+                                          ),
+                                        ),
+                                      );
+                                    } else {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) => DetailScreen(
+                                            title: item.toString(),
+                                            menuItems: menuItemsJenis1,
+                                          ),
+                                        ),
+                                      );
+                                    }
+                                  },
+                                );
+                              },
+                            );
+                          } else {
+                            return const Center(child: Text('Belum ada data.'));
                           }
-                          return tile;
-                        },
-                      );
-                    } else if (widget.menuData.isNotEmpty &&
-                        widget.menuData.first is String) {
-                      // Fallback jika masih List<String> atau List menu bercabang
-                      return ListView.builder(
-                        itemCount: widget.menuData.length,
-                        itemBuilder: (context, index) {
-                          final item = widget.menuData[index];
-                          return ReusableListTileWidget(
-                            value: null,
-                            titleText: item.toString(),
-                            onTap: () {
-                              if (item is List) {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => MenuScreen(
-                                      args: MenuScreenArgs(
-                                          title: item.toString()),
-                                      menuData: item,
-                                    ),
-                                  ),
-                                );
-                              } else {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => DetailScreen(
-                                      title: item.toString(),
-                                      menuItems: menuItemsJenis1,
-                                    ),
-                                  ),
-                                );
-                              }
-                            },
-                          );
-                        },
-                      );
-                    } else {
-                      return const Center(child: Text('Belum ada data.'));
-                    }
-                  } else {
-                    return const Center(child: Text('Belum ada data.'));
-                  }
-                },
+                        } else {
+                          return const Center(child: Text('Belum ada data.'));
+                        }
+                      },
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                ),
               ),
-            ),
-          ],
+            );
+          },
         ),
         bottomNavigationBar: BottomBanner(
           imageUrl: banner?.resolvedBottomBannerUrl,

--- a/lib/screens/prestasi_santri_screen.dart
+++ b/lib/screens/prestasi_santri_screen.dart
@@ -216,50 +216,59 @@ class _PrestasiSantriScreenState extends State<PrestasiSantriScreen> {
 
     return Scaffold(
       backgroundColor: AppColors.primaryGreen,
-      body: Column(
-        children: [
-          if (_errorMessage != null)
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
-              color: Colors.orange.shade100,
-              child: Row(
-                children: [
-                  Icon(Icons.info_outline,
-                      color: Colors.orange.shade700, size: 20),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      _errorMessage!,
-                      style: TextStyle(
-                          color: Colors.orange.shade900, fontSize: 12),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+      body: RefreshIndicator(
+        color: AppColors.primaryGreen,
+        onRefresh: () => _fetchPrestasiData(
+            tahun: selectedYear, tingkat: selectedTingkat),
+        child: CustomScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          slivers: [
+            if (_errorMessage != null)
+              SliverToBoxAdapter(
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  color: Colors.orange.shade100,
+                  child: Row(
+                    children: [
+                      Icon(Icons.info_outline,
+                          color: Colors.orange.shade700, size: 20),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          _errorMessage!,
+                          style: TextStyle(
+                              color: Colors.orange.shade900, fontSize: 12),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
-          _buildHeader(),
-          Expanded(
-            child: Container(
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.only(
-                  topLeft: Radius.circular(30),
-                  topRight: Radius.circular(30),
                 ),
               ),
-              child: Column(
-                children: [
-                  _buildFilters(),
-                  _buildStats(),
-                  Expanded(child: _buildPrestasiList()),
-                ],
+            SliverToBoxAdapter(child: _buildHeader()),
+            SliverToBoxAdapter(
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(30),
+                    topRight: Radius.circular(30),
+                  ),
+                ),
+                child: Column(
+                  children: [
+                    _buildFilters(),
+                    _buildStats(),
+                    _buildPrestasiList(),
+                    const SizedBox(height: 24),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -635,21 +644,18 @@ class _PrestasiSantriScreenState extends State<PrestasiSantriScreen> {
             ),
           ),
           const SizedBox(height: 12),
-          Expanded(
-            child: filteredPrestasi.isEmpty
-                ? _buildEmptyState()
-                : RefreshIndicator(
-                    onRefresh: () => _fetchPrestasiData(
-                        tahun: selectedYear, tingkat: selectedTingkat),
-                    child: ListView.builder(
-                      itemCount: filteredPrestasi.length,
-                      itemBuilder: (context, index) {
-                        final prestasi = filteredPrestasi[index];
-                        return _buildPrestasiCard(prestasi, index);
-                      },
-                    ),
-                  ),
-          ),
+          if (filteredPrestasi.isEmpty)
+            SizedBox(height: 200, child: _buildEmptyState())
+          else
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: filteredPrestasi.length,
+              itemBuilder: (context, index) {
+                final prestasi = filteredPrestasi[index];
+                return _buildPrestasiCard(prestasi, index);
+              },
+            ),
         ],
       ),
     );

--- a/lib/screens/statistics_screen.dart
+++ b/lib/screens/statistics_screen.dart
@@ -95,41 +95,46 @@ class StatisticsScreen extends StatelessWidget {
       child: Scaffold(
         backgroundColor: Colors.grey[100],
         appBar: TopBar(title: title),
-        body: Column(
-          children: [
-            const TopBanner(assetPath: 'assets/banners/top.png'),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    // Header dengan total - menggunakan desain asli
+                    const TopBanner(assetPath: 'assets/banners/top.png'),
                     Padding(
-                      padding: const EdgeInsets.only(top: 16, bottom: 16),
-                      child: _CustomListTile(
-                        title: 'TOTAL',
-                        value: total.toString(),
-                        isTotal: true,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    // List per tahun - menggunakan desain asli
-                    ...convertedData
-                        .map((item) => Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const SizedBox(height: 16),
+                          _CustomListTile(
+                            title: 'TOTAL',
+                            value: total.toString(),
+                            isTotal: true,
+                          ),
+                          const SizedBox(height: 16),
+                          ...convertedData.map(
+                            (item) => Padding(
                               padding: const EdgeInsets.only(bottom: 8),
                               child: _CustomListTile(
                                 title: item['lembaga'],
                                 value: item['jumlah'].toString(),
                                 isTotal: false,
                               ),
-                            ))
-                        .toList(),
-                    const SizedBox(height: 16),
+                            ),
+                          ),
+                          const SizedBox(height: 32),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
               ),
-            ),
-          ],
+            );
+          },
         ),
         bottomNavigationBar:
             const BottomBanner(assetPath: 'assets/banners/bottom.png'),

--- a/lib/widgets/achievement_section.dart
+++ b/lib/widgets/achievement_section.dart
@@ -84,16 +84,21 @@ class _AchievementSectionState extends State<AchievementSection> {
       );
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ...achievements
-            .map((achievement) => AchievementItem(
-                  achievement: achievement,
-                ))
-            .toList(),
-        const SizedBox(height: 72),
-      ],
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      padding: EdgeInsets.zero,
+      itemCount: achievements.length + 1,
+      itemBuilder: (context, index) {
+        if (index == achievements.length) {
+          return const SizedBox(height: 72);
+        }
+
+        final achievement = achievements[index];
+        return AchievementItem(
+          achievement: achievement,
+        );
+      },
     );
   }
 }

--- a/lib/widgets/detail_layout.dart
+++ b/lib/widgets/detail_layout.dart
@@ -28,23 +28,30 @@ class DetailLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Left side - Images
-          Container(
-            width: imageWidth + 20, // Tambah padding 20px untuk margin
-            child: _buildImagesList(),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Left side - Images
+                SizedBox(
+                  width: imageWidth + 20, // Tambah padding 20px untuk margin
+                  child: _buildImagesList(),
+                ),
+                const SizedBox(width: 16),
+                // Right side - Menu items
+                Flexible(
+                  child: _buildMenuList(),
+                ),
+              ],
+            ),
           ),
-          const SizedBox(width: 16),
-          // Right side - Menu items
-          Flexible(
-            child: _buildMenuList(),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- convert major screen layouts to scrollable wrappers so content remains accessible on shorter displays
- restructure data-heavy screens to integrate filters, stats, and lists inside scrollable containers while keeping refresh behaviour intact
- adjust the achievement section list to cooperate with parent scroll views without nested scrolling conflicts

## Testing
- not run (flutter tooling unavailable)

------
https://chatgpt.com/codex/tasks/task_e_68e39b3df0208331b6d7207445588d07