### PR TITLE
Improve home screen responsiveness and markdown readability

### DIFF
--- a/lib/core/config/markdown_config.dart
+++ b/lib/core/config/markdown_config.dart
@@ -3,82 +3,64 @@ import 'package:markdown_widget/markdown_widget.dart';
 
 /// Centralized Markdown configuration for consistent styling across the app
 class AppMarkdownConfig {
-  /// Default markdown configuration used throughout the application
-  static MarkdownConfig get defaultConfig => MarkdownConfig(configs: [
-        // Heading 1 configuration
-        H1Config(
-          style: const TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.bold,
-            color: Colors.black,
-          ),
-        ),
+  static MarkdownConfig get defaultConfig => _buildConfig(compact: false);
 
-        // Heading 2 configuration
-        H2Config(
-          style: const TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-            color: Colors.black87,
-          ),
-        ),
+  static MarkdownConfig get compactConfig => _buildConfig(compact: true);
 
-        // Heading 3 configuration
-        H3Config(
-          style: const TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.bold,
-            color: Colors.black87,
-          ),
-        ),
+  /// Returns a markdown configuration adapted to the current screen size.
+  ///
+  /// Small devices (shortest side under 360dp) or devices with a large
+  /// text scale factor automatically use the compact configuration to keep
+  /// text — especially inside tables — readable without overflowing.
+  static MarkdownConfig responsiveConfig(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final shortestSide = mediaQuery.size.shortestSide;
+    final isTextScaledUp = mediaQuery.textScaleFactor > 1.1;
+    final bool useCompact = shortestSide < 360 || isTextScaledUp;
+    return useCompact ? compactConfig : defaultConfig;
+  }
 
-        // Paragraph configuration
-        PConfig(
-          textStyle: const TextStyle(
-            fontSize: 16,
-            height: 1.5,
-            color: Colors.black87,
-          ),
-        ),
+  static MarkdownConfig _buildConfig({required bool compact}) {
+    final double h1Size = compact ? 20 : 22;
+    final double h2Size = compact ? 18 : 20;
+    final double h3Size = compact ? 16 : 18;
+    final double paragraphSize = compact ? 13 : 15;
 
-        // Link configuration
-        LinkConfig(
-          style: const TextStyle(
-            color: Color(0xFF2E7D32),
-            decoration: TextDecoration.underline,
-          ),
+    return MarkdownConfig(configs: [
+      H1Config(
+        style: TextStyle(
+          fontSize: h1Size,
+          fontWeight: FontWeight.bold,
+          color: Colors.black,
         ),
-      ]);
-
-  /// Compact markdown configuration for smaller spaces
-  static MarkdownConfig get compactConfig => MarkdownConfig(configs: [
-        H1Config(
-          style: const TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-            color: Colors.black,
-          ),
+      ),
+      H2Config(
+        style: TextStyle(
+          fontSize: h2Size,
+          fontWeight: FontWeight.bold,
+          color: Colors.black87,
         ),
-        H2Config(
-          style: const TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.bold,
-            color: Colors.black87,
-          ),
+      ),
+      H3Config(
+        style: TextStyle(
+          fontSize: h3Size,
+          fontWeight: FontWeight.bold,
+          color: Colors.black87,
         ),
-        H3Config(
-          style: const TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            color: Colors.black87,
-          ),
+      ),
+      PConfig(
+        textStyle: TextStyle(
+          fontSize: paragraphSize,
+          height: 1.45,
+          color: Colors.black87,
         ),
-        PConfig(
-          textStyle: const TextStyle(
-            fontSize: 14,
-            height: 1.4,
-            color: Colors.black87,
-          ),
+      ),
+      LinkConfig(
+        style: const TextStyle(
+          color: Color(0xFF2E7D32),
+          decoration: TextDecoration.underline,
         ),
-      ]);
+      ),
+    ]);
+  }
 }

--- a/lib/screens/bannered_detail_screen.dart
+++ b/lib/screens/bannered_detail_screen.dart
@@ -74,7 +74,7 @@ class BanneredDetailScreen extends StatelessWidget {
                               const SizedBox(height: 12),
                             ],
                             // Render content as markdown if it contains markdown syntax
-                            _renderSectionContent(section.content),
+                            _renderSectionContent(context, section.content),
                           ],
                         ),
                       ),
@@ -90,7 +90,7 @@ class BanneredDetailScreen extends StatelessWidget {
   }
 
   /// Render section content - detect if it's markdown and render appropriately
-  Widget _renderSectionContent(String content) {
+  Widget _renderSectionContent(BuildContext context, String content) {
     // Check if content contains markdown syntax
     bool isMarkdown = content.contains('#') ||
         content.contains('**') ||
@@ -102,7 +102,7 @@ class BanneredDetailScreen extends StatelessWidget {
       // Render as markdown with centralized configuration
       return MarkdownBlock(
         data: content,
-        config: AppMarkdownConfig.defaultConfig,
+        config: AppMarkdownConfig.responsiveConfig(context),
       );
     } else {
       // Render as plain text

--- a/lib/screens/content_screen.dart
+++ b/lib/screens/content_screen.dart
@@ -39,8 +39,8 @@ class ContentScreen extends StatelessWidget {
           backgroundColor: Colors.green.shade700,
         ),
         body: type == ContentScreenType.minimal
-            ? _buildMinimalLayout(padding)
-            : _buildFullLayout(padding, innerPadding),
+            ? _buildMinimalLayout(context, padding)
+            : _buildFullLayout(context, padding, innerPadding),
         bottomNavigationBar: type == ContentScreenType.full
             ? BottomBanner(assetPath: 'assets/banners/bottom.png')
             : null,
@@ -48,7 +48,8 @@ class ContentScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildFullLayout(double padding, double innerPadding) {
+  Widget _buildFullLayout(
+      BuildContext context, double padding, double innerPadding) {
     return Column(
       children: [
         TopBanner(
@@ -67,7 +68,7 @@ class ContentScreen extends StatelessWidget {
                   fontSize: 20,
                 ),
                 SizedBox(height: innerPadding),
-                _buildMarkdownWidget(),
+                _buildMarkdownWidget(context),
               ],
             ),
           ),
@@ -76,14 +77,14 @@ class ContentScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildMinimalLayout(double padding) {
+  Widget _buildMinimalLayout(BuildContext context, double padding) {
     return SingleChildScrollView(
       padding: EdgeInsets.all(padding),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (markdownContent != null && markdownContent!.isNotEmpty)
-            _buildMarkdownWidget()
+            _buildMarkdownWidget(context)
           else
             const Center(
               child: Text(
@@ -96,12 +97,12 @@ class ContentScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildMarkdownWidget() {
+  Widget _buildMarkdownWidget(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(16.0),
       child: MarkdownBlock(
         data: markdownContent ?? '',
-        config: AppMarkdownConfig.defaultConfig,
+        config: AppMarkdownConfig.responsiveConfig(context),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:provider/provider.dart';
@@ -72,11 +74,32 @@ class _HomeScreenState extends State<HomeScreen> {
     final sliderProvider = context.watch<SliderProvider>();
     final sliderState = sliderProvider.sliderState;
     final images = sliderProvider.imageUrls;
+    final mediaQuery = MediaQuery.of(context);
+    final screenWidth = mediaQuery.size.width;
+    final screenHeight = mediaQuery.size.height;
+    final isCompactWidth = screenWidth < 360;
+    final isCompactHeight = screenHeight < 640;
+    final sliderHeight = isCompactHeight
+        ? 120.0
+        : (isCompactWidth
+            ? 135.0
+            : 150.0); // Reduce slider height on compact displays
+    final menuButtonSize = isCompactWidth
+        ? 34.0
+        : (isCompactHeight ? 36.0 : 40.0); // Button size tuned for small screens
+    final menuLabelFontSize = isCompactWidth
+        ? 7.5
+        : (isCompactHeight ? 8.0 : 9.0); // Smaller labels for compact devices
+    final menuVerticalPadding = isCompactHeight ? 12.0 : 16.0;
+    final menuRowSpacing = (isCompactWidth || isCompactHeight) ? 4.0 : 6.0;
+    final horizontalMenuPadding = isCompactWidth ? 4.0 : 8.0;
+    final minItemWidth = isCompactWidth ? 60.0 : 64.0;
+    final maxItemWidth = isCompactWidth ? 88.0 : 96.0;
 
-    Widget _buildSlider() {
+    Widget buildSlider() {
       if (sliderState.isLoading && !sliderState.hasLoaded) {
         return Container(
-          height: 150.0, // Reduced height to save space
+          height: sliderHeight,
           color: Colors.grey.shade200,
           child: const Center(child: CircularProgressIndicator()),
         );
@@ -84,7 +107,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
       if (sliderState.errorMessage != null && images.isEmpty) {
         return Container(
-          height: 150.0, // Reduced height to save space
+          height: sliderHeight,
           color: Colors.red.shade100,
           child: Center(
             child: Text('Error: ${sliderState.errorMessage}'),
@@ -94,7 +117,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
       if (images.isEmpty) {
         return Container(
-          height: 150.0, // Reduced height to save space
+          height: sliderHeight,
           color: Colors.grey.shade100,
           child: const Center(child: Text('No images available')),
         );
@@ -102,7 +125,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
       return CarouselSlider(
         options: CarouselOptions(
-          height: 150.0, // Reduced height to save space
+          height: sliderHeight,
           autoPlay: true,
           enlargeCenterPage: true,
           viewportFraction: 1.0,
@@ -145,20 +168,27 @@ class _HomeScreenState extends State<HomeScreen> {
         body: Column(
           children: [
             // Carousel dengan Provider - tidak scrollable
-            _buildSlider(),
+            buildSlider(),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 1, vertical: 1),
               child: Material(
                 elevation: 12,
                 borderRadius: BorderRadius.circular(12),
                 child: Container(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  padding: EdgeInsets.symmetric(
+                    vertical: menuVerticalPadding,
+                    horizontal: horizontalMenuPadding,
+                  ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       MenuRow(
                         items: [HomeScreen._menuItems[0]],
-                        buttonSize: 40,
+                        buttonSize: menuButtonSize,
+                        labelFontSize: menuLabelFontSize,
+                        horizontalPadding: 0,
+                        minItemWidth: minItemWidth,
+                        maxItemWidth: maxItemWidth,
                         onTap: (title) {
                           Navigator.pushNamed(
                             context,
@@ -167,26 +197,38 @@ class _HomeScreenState extends State<HomeScreen> {
                           );
                         },
                       ),
-                      const SizedBox(height: 6),
+                      SizedBox(height: menuRowSpacing),
                       MenuRow(
                         items: HomeScreen._menuItems.sublist(1, 4),
-                        buttonSize: 40,
+                        buttonSize: menuButtonSize,
+                        labelFontSize: menuLabelFontSize,
+                        horizontalPadding: 0,
+                        minItemWidth: minItemWidth,
+                        maxItemWidth: maxItemWidth,
                         onTap: (title) {
                           showComingSoonSnackbar(context);
                         },
                       ),
-                      const SizedBox(height: 6),
+                      SizedBox(height: menuRowSpacing),
                       MenuRow(
                         items: HomeScreen._menuItems.sublist(4, 7),
-                        buttonSize: 40,
+                        buttonSize: menuButtonSize,
+                        labelFontSize: menuLabelFontSize,
+                        horizontalPadding: 0,
+                        minItemWidth: minItemWidth,
+                        maxItemWidth: maxItemWidth,
                         onTap: (title) {
                           showComingSoonSnackbar(context);
                         },
                       ),
-                      const SizedBox(height: 6),
+                      SizedBox(height: menuRowSpacing),
                       MenuRow(
                         items: HomeScreen._menuItems.sublist(7, 10),
-                        buttonSize: 40,
+                        buttonSize: menuButtonSize,
+                        labelFontSize: menuLabelFontSize,
+                        horizontalPadding: 0,
+                        minItemWidth: minItemWidth,
+                        maxItemWidth: maxItemWidth,
                         onTap: (title) {
                           if (title == 'DONASI') {
                             Navigator.pushNamed(context, AppRouter.donasi);
@@ -201,10 +243,14 @@ class _HomeScreenState extends State<HomeScreen> {
                           }
                         },
                       ),
-                      const SizedBox(height: 6),
+                      SizedBox(height: menuRowSpacing),
                       MenuRow(
                         items: [HomeScreen._menuItems[10]],
-                        buttonSize: 40,
+                        buttonSize: menuButtonSize,
+                        labelFontSize: menuLabelFontSize,
+                        horizontalPadding: 0,
+                        minItemWidth: minItemWidth,
+                        maxItemWidth: maxItemWidth,
                         alignment: MainAxisAlignment.center,
                         onTap: (title) {
                           if (title == 'AKUN') {
@@ -258,30 +304,54 @@ class MenuRow extends StatelessWidget {
   final void Function(String title) onTap;
   final double buttonSize;
   final MainAxisAlignment alignment;
+  final double labelFontSize;
+  final double horizontalPadding;
+  final double minItemWidth;
+  final double maxItemWidth;
   const MenuRow(
       {super.key,
       required this.items,
       required this.onTap,
       this.buttonSize = 40, // Default smaller size
-      this.alignment = MainAxisAlignment.spaceEvenly});
+      this.alignment = MainAxisAlignment.spaceEvenly,
+      this.labelFontSize = 9,
+      this.horizontalPadding = 8,
+      this.minItemWidth = 64,
+      this.maxItemWidth = 96});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding:
-          const EdgeInsets.symmetric(horizontal: 8), // Add horizontal padding
-      child: Row(
-        mainAxisAlignment: alignment,
-        children: [
-          for (final item in items)
-            MenuButton(
-              title: item.title,
-              iconPath: item.iconPath,
-              iconData: item.iconData,
-              buttonSize: buttonSize,
-              onTap: () => onTap(item.title),
-            ),
-        ],
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final availableWidth = constraints.maxWidth;
+          final itemCount = items.length;
+          if (itemCount == 0) {
+            return const SizedBox.shrink();
+          }
+          final baseWidth = availableWidth / itemCount;
+          final itemWidth = baseWidth.clamp(minItemWidth, maxItemWidth);
+          final adjustedButtonSize = math.min(buttonSize, itemWidth * 0.78);
+
+          return Row(
+            mainAxisAlignment: alignment,
+            children: [
+              for (final item in items)
+                SizedBox(
+                  width: itemWidth,
+                  child: MenuButton(
+                    title: item.title,
+                    iconPath: item.iconPath,
+                    iconData: item.iconData,
+                    buttonSize: adjustedButtonSize,
+                    labelFontSize: labelFontSize,
+                    onTap: () => onTap(item.title),
+                  ),
+                ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/screens/informasi_ittifaqiah_screen.dart
+++ b/lib/screens/informasi_ittifaqiah_screen.dart
@@ -335,7 +335,7 @@ class _ProfilScreen extends StatelessWidget {
                     // Display markdown content from API with proper formatting
                     MarkdownBlock(
                       data: profilMd,
-                      config: AppMarkdownConfig.defaultConfig,
+                      config: AppMarkdownConfig.responsiveConfig(context),
                     ),
                     const SizedBox(height: 16),
                   ],

--- a/lib/widgets/menu_button.dart
+++ b/lib/widgets/menu_button.dart
@@ -13,6 +13,7 @@ class MenuButton extends StatelessWidget {
   final IconData? iconData;
   final VoidCallback onTap;
   final double buttonSize;
+  final double labelFontSize;
 
   const MenuButton({
     super.key,
@@ -21,6 +22,7 @@ class MenuButton extends StatelessWidget {
     this.iconData,
     required this.onTap,
     this.buttonSize = 48,
+    this.labelFontSize = 9,
   })  : assert(iconPath != null || iconData != null,
             'Either iconPath or iconData must be provided.'),
         assert(iconPath == null || iconData == null,
@@ -63,10 +65,11 @@ class MenuButton extends StatelessWidget {
             Text(
               title,
               textAlign: TextAlign.center,
-              style: const TextStyle(
-                  fontSize: 9,
-                  fontWeight: FontWeight.bold,
-                  color: AppColors.primaryGreen),
+              style: TextStyle(
+                fontSize: labelFontSize,
+                fontWeight: FontWeight.bold,
+                color: AppColors.primaryGreen,
+              ),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),


### PR DESCRIPTION
## Summary
- adjust the home screen carousel height, menu button sizing, and spacing so the layout fits compact phone screens without overflow
- add responsive markdown configuration selection and apply it across markdown renders to shrink typography on small displays

## Testing
- Not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f62cdcdea48331b213168f8f5f3ced